### PR TITLE
Add Tkinter GUI with 12 tools

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -1,0 +1,39 @@
+# This workflow will install Python dependencies, run tests and lint with a single version of Python
+# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-python
+
+name: Python application
+
+on:
+  push:
+    branches: [ "TuxPad" ]
+  pull_request:
+    branches: [ "TuxPad" ]
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up Python 3.10
+      uses: actions/setup-python@v3
+      with:
+        python-version: "3.10"
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install flake8 pytest
+        if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+    - name: Lint with flake8
+      run: |
+        # stop the build if there are Python syntax errors or undefined names
+        flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+        # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
+        flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+    - name: Test with pytest
+      run: |
+        pytest

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,21 @@
+CFLAGS=-Wall -Wextra -I./src
+CXXFLAGS=$(CFLAGS)
+
+all: tuxpad
+
+src/editor_features.o: src/editor_features.cpp src/editor_features.h
+	$(CXX) $(CXXFLAGS) -c $< -o $@
+
+src/main.o: src/main.c src/editor_features.h
+	$(CC) $(CFLAGS) -c $< -o $@
+
+TUXPAD_OBJS=src/main.o src/editor_features.o
+
+tuxpad: $(TUXPAD_OBJS)
+	$(CXX) $(CXXFLAGS) $^ -o $@
+
+gui:
+	python3 scripts/editor_gui.py
+
+clean:
+	rm -f src/*.o tuxpad

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ You can also run the GUI on its own:
 python3 scripts/editor_gui.py
 ```
 
-The GUI exposes the following twelve tools:
+The GUI exposes the following fifteen tools:
 
 1. New
 2. Open
@@ -49,6 +49,9 @@ The GUI exposes the following twelve tools:
 10. Preferences
 11. Plugins
 12. Build & Run
+13. Spell Check
+14. Format Python
+15. Word Frequency
 
 ### Plugins
 
@@ -79,6 +82,33 @@ If Pygments is not installed you can get it with:
 
 ```sh
 pip install pygments
+```
+
+#### Spell check plugin
+
+The **spellcheck** plugin relies on the `pyspellchecker` library to detect
+misspelled words and underline them in red. Install it with:
+
+```sh
+pip install pyspellchecker
+```
+
+#### Auto-format plugin
+
+The **autoformat** plugin uses [Black](https://black.readthedocs.io/) to format
+Python code in the editor. Install Black with:
+
+```sh
+pip install black
+```
+
+#### Word frequency plugin
+
+The **freq_plot** plugin uses `matplotlib` to display a bar chart of the most
+common words in the current document. You can install matplotlib via:
+
+```sh
+pip install matplotlib
 ```
 
 ### Build & Run

--- a/README.md
+++ b/README.md
@@ -50,6 +50,18 @@ The GUI exposes the following twelve tools:
 11. Plugins
 12. Build & Run
 
+### Plugins
+
+Plugins are simple Python modules placed in the `plugins/` directory. Each
+plugin must provide a `run(gui)` function. The plugin manager (accessible from
+`Tools -> Plugins`) lists available plugins and lets you execute them on the
+current document.
+
+### Build & Run
+
+The *Build & Run* command runs `make` in the repository root and then launches
+the freshly built `tuxpad` binary on the currently loaded file, if any.
+
 ## Cleaning
 
 To clean build artifacts run:

--- a/README.md
+++ b/README.md
@@ -1,2 +1,59 @@
 # VEN
-VEN is a code editor built like Vim but have more to offer 
+
+VEN is a prototype code editor that experiments with a mix of C, C++ and Python.
+This repository contains a minimal cross-language example to demonstrate how
+these languages can work together.
+
+## Building
+
+Use `make` to build the `tuxpad` binary:
+
+```sh
+make
+```
+
+To open the GUI without running the C program you can run:
+
+```sh
+make gui
+```
+
+Run the program by providing a file name:
+
+```sh
+./tuxpad path/to/file.txt
+```
+
+The program counts the number of lines in the file using a C++ helper and then
+launches a Python Tkinter GUI that demonstrates a dozen editor tools.
+
+### Launching the GUI directly
+
+You can also run the GUI on its own:
+
+```sh
+python3 scripts/editor_gui.py
+```
+
+The GUI exposes the following twelve tools:
+
+1. New
+2. Open
+3. Save
+4. Close
+5. Search
+6. Replace
+7. Undo
+8. Redo
+9. Highlight
+10. Preferences
+11. Plugins
+12. Build & Run
+
+## Cleaning
+
+To clean build artifacts run:
+
+```sh
+make clean
+```

--- a/README.md
+++ b/README.md
@@ -57,6 +57,30 @@ plugin must provide a `run(gui)` function. The plugin manager (accessible from
 `Tools -> Plugins`) lists available plugins and lets you execute them on the
 current document.
 
+#### Highlight plugin
+
+The bundled **highlight** plugin uses the [Pygments](https://pygments.org)
+library to provide syntax highlighting for twelve languages:
+
+* Python
+* C
+* C++
+* Java
+* JavaScript
+* HTML
+* CSS
+* Ruby
+* Go
+* Rust
+* Bash
+* Markdown
+
+If Pygments is not installed you can get it with:
+
+```sh
+pip install pygments
+```
+
 ### Build & Run
 
 The *Build & Run* command runs `make` in the repository root and then launches

--- a/plugins/autoformat.py
+++ b/plugins/autoformat.py
@@ -1,0 +1,30 @@
+"""Auto-format Python code using Black."""
+
+import tkinter as tk
+from tkinter import messagebox
+
+try:
+    import black
+except ImportError:  # pragma: no cover - optional dependency
+    black = None
+
+
+def run(gui=None):
+    if gui is None:
+        print("Autoformat plugin requires a GUI context")
+        return
+    if black is None:
+        messagebox.showerror("Format", "black is not installed")
+        return
+
+    text_widget = gui.text
+    code = text_widget.get("1.0", "end-1c")
+    try:
+        formatted = black.format_str(code, mode=black.FileMode())
+    except Exception as exc:
+        messagebox.showerror("Format", str(exc))
+        return
+
+    text_widget.delete("1.0", tk.END)
+    text_widget.insert(tk.END, formatted)
+    messagebox.showinfo("Format", "Formatted with Black")

--- a/plugins/freq_plot.py
+++ b/plugins/freq_plot.py
@@ -1,0 +1,37 @@
+"""Word frequency plot plugin using matplotlib."""
+
+import re
+from collections import Counter
+import tkinter as tk
+from tkinter import messagebox
+
+try:
+    import matplotlib.pyplot as plt
+except ImportError:  # pragma: no cover - optional dependency
+    plt = None
+
+
+def run(gui=None):
+    if gui is None:
+        print("Frequency plot plugin requires a GUI context")
+        return
+    if plt is None:
+        messagebox.showerror("Word Frequency", "matplotlib is not installed")
+        return
+
+    text = gui.text.get("1.0", "end-1c").lower()
+    words = re.findall(r"\w+", text)
+    counts = Counter(words)
+
+    if not counts:
+        messagebox.showinfo("Word Frequency", "No words to plot")
+        return
+
+    most = counts.most_common(10)
+    labels, values = zip(*most)
+    plt.figure(figsize=(6, 4))
+    plt.bar(labels, values)
+    plt.xticks(rotation=45, ha="right")
+    plt.title("Word Frequency")
+    plt.tight_layout()
+    plt.show()

--- a/plugins/highlight.py
+++ b/plugins/highlight.py
@@ -1,12 +1,89 @@
-"""Highlight plugin for Tuxpad."""
+"""Syntax highlighting plugin for Tuxpad."""
+
+import tkinter as tk
+from tkinter import messagebox
+from pygments import lex
+from pygments.lexers import get_lexer_by_name
+from pygments.token import Token
+
+LANGUAGES = {
+    "Python": "python",
+    "C": "c",
+    "C++": "cpp",
+    "Java": "java",
+    "JavaScript": "javascript",
+    "HTML": "html",
+    "CSS": "css",
+    "Ruby": "ruby",
+    "Go": "go",
+    "Rust": "rust",
+    "Bash": "bash",
+    "Markdown": "markdown",
+}
+
+COLOR_MAP = {
+    Token.Keyword: "blue",
+    Token.Name: "black",
+    Token.Comment: "grey",
+    Token.String: "green",
+    Token.Number: "purple",
+    Token.Operator: "red",
+}
+
+
+def _get_color(tok):
+    while tok not in COLOR_MAP and tok.parent is not None:
+        tok = tok.parent
+    return COLOR_MAP.get(tok, "black")
+
+
+def apply_highlight(gui, lang):
+    text_widget = gui.text
+    code = text_widget.get("1.0", "end-1c")
+    lexer = get_lexer_by_name(lang, stripall=True)
+
+    # Remove old highlight tags
+    for tag in text_widget.tag_names():
+        if tag.startswith("tok_"):
+            text_widget.tag_delete(tag)
+
+    offset = 0
+    for tok, value in lex(code, lexer):
+        length = len(value)
+        if length == 0:
+            continue
+        start = f"1.0 + {offset}c"
+        end = f"1.0 + {offset + length}c"
+        color = _get_color(tok)
+        tag = f"tok_{tok}"
+        if not text_widget.tag_cget(tag, "foreground"):
+            text_widget.tag_config(tag, foreground=color)
+        text_widget.tag_add(tag, start, end)
+        offset += length
+
 
 def run(gui=None):
-    print("Running highlight plugin")
-    # Placeholder for actual highlighting logic
-    if gui:
+    """Run the highlight plugin with a simple language selector."""
+    if gui is None:
+        print("Highlight plugin requires a GUI context")
+        return
+
+    win = tk.Toplevel(gui.root)
+    win.title("Highlight")
+
+    var = tk.StringVar(win)
+    var.set("python")
+    options = tk.OptionMenu(win, var, *LANGUAGES.values())
+    options.pack(padx=10, pady=10)
+
+    def _do_highlight():
+        lang = var.get()
+        apply_highlight(gui, lang)
         try:
-            from tkinter import messagebox
-            messagebox.showinfo("Highlight", "Highlight plugin executed")
+            messagebox.showinfo("Highlight", f"Applied {lang} highlighting")
         except Exception:
             pass
+        win.destroy()
+
+    tk.Button(win, text="Highlight", command=_do_highlight).pack(pady=5)
 

--- a/plugins/highlight.py
+++ b/plugins/highlight.py
@@ -1,0 +1,12 @@
+"""Highlight plugin for Tuxpad."""
+
+def run(gui=None):
+    print("Running highlight plugin")
+    # Placeholder for actual highlighting logic
+    if gui:
+        try:
+            from tkinter import messagebox
+            messagebox.showinfo("Highlight", "Highlight plugin executed")
+        except Exception:
+            pass
+

--- a/plugins/spellcheck.py
+++ b/plugins/spellcheck.py
@@ -1,0 +1,42 @@
+"""Spell check plugin using pyspellchecker."""
+
+import tkinter as tk
+from tkinter import messagebox
+
+try:
+    from spellchecker import SpellChecker
+except ImportError:  # pragma: no cover - optional dependency
+    SpellChecker = None
+
+
+def run(gui=None):
+    if gui is None:
+        print("Spell check plugin requires a GUI context")
+        return
+    if SpellChecker is None:
+        messagebox.showerror("Spell Check", "pyspellchecker is not installed")
+        return
+
+    text_widget = gui.text
+    text = text_widget.get("1.0", "end-1c")
+    spell = SpellChecker()
+    misspelled = spell.unknown(text.split())
+
+    text_widget.tag_remove("spell_error", "1.0", tk.END)
+
+    if not misspelled:
+        messagebox.showinfo("Spell Check", "No spelling mistakes found")
+        return
+
+    for word in misspelled:
+        start = "1.0"
+        while True:
+            pos = text_widget.search(word, start, tk.END)
+            if not pos:
+                break
+            end = f"{pos}+{len(word)}c"
+            text_widget.tag_add("spell_error", pos, end)
+            start = end
+
+    text_widget.tag_config("spell_error", underline=True, foreground="red")
+    messagebox.showinfo("Spell Check", f"Found {len(misspelled)} mistakes")

--- a/plugins/wordcount.py
+++ b/plugins/wordcount.py
@@ -1,0 +1,17 @@
+"""Word count plugin for Tuxpad."""
+
+import re
+
+def run(gui=None):
+    if not gui:
+        print("No GUI context provided")
+        return
+    text = gui.text.get("1.0", "end-1c")
+    words = re.findall(r"\w+", text)
+    count = len(words)
+    try:
+        from tkinter import messagebox
+        messagebox.showinfo("Word Count", f"Document has {count} words")
+    except Exception:
+        print(f"Word count: {count}")
+

--- a/scripts/editor_gui.py
+++ b/scripts/editor_gui.py
@@ -1,8 +1,57 @@
 import os
 import sys
 import subprocess
+import importlib.util
 import tkinter as tk
 from tkinter import filedialog, messagebox
+
+
+class PluginManager:
+    """Simple plugin manager that loads plugins from the ../plugins directory."""
+
+    def __init__(self, gui):
+        self.gui = gui
+        self.plugins_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', 'plugins'))
+
+    def list_plugins(self):
+        return [f[:-3] for f in os.listdir(self.plugins_dir)
+                if f.endswith('.py') and f != '__init__.py']
+
+    def load_plugin(self, name):
+        path = os.path.join(self.plugins_dir, f"{name}.py")
+        if not os.path.exists(path):
+            return None
+        spec = importlib.util.spec_from_file_location(name, path)
+        mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(mod)
+        return mod
+
+    def run_plugin(self, name):
+        mod = self.load_plugin(name)
+        if mod and hasattr(mod, 'run'):
+            try:
+                mod.run(self.gui)
+            except Exception as exc:
+                messagebox.showerror('Plugin Error', str(exc))
+        else:
+            messagebox.showwarning('Plugin', f'Plugin {name} has no run()')
+
+    def open_window(self):
+        win = tk.Toplevel(self.gui.root)
+        win.title('Plugins')
+        lb = tk.Listbox(win)
+        for p in self.list_plugins():
+            lb.insert(tk.END, p)
+        lb.pack(side=tk.LEFT, fill=tk.BOTH, expand=True)
+
+        def run_selected():
+            sel = lb.curselection()
+            if sel:
+                name = lb.get(sel[0])
+                self.run_plugin(name)
+
+        run_btn = tk.Button(win, text='Run', command=run_selected)
+        run_btn.pack(side=tk.RIGHT)
 
 
 class TuxpadGUI:
@@ -13,6 +62,9 @@ class TuxpadGUI:
         self.text.pack(expand=True, fill=tk.BOTH)
         self.filename = None
         self.create_menus()
+
+        # plugin manager
+        self.plugin_manager = PluginManager(self)
 
     def create_menus(self):
         menubar = tk.Menu(self.root)
@@ -76,17 +128,21 @@ class TuxpadGUI:
         messagebox.showinfo("Replace", "Replace feature not implemented yet.")
 
     def highlight(self):
-        script = os.path.join(os.path.dirname(__file__), 'highlight.py')
-        subprocess.run([sys.executable, script])
+        self.plugin_manager.run_plugin('highlight')
 
     def preferences(self):
         messagebox.showinfo("Preferences", "Preferences dialog not implemented yet.")
 
     def plugins(self):
-        messagebox.showinfo("Plugins", "Plugin manager not implemented yet.")
+        self.plugin_manager.open_window()
 
     def build_run(self):
-        messagebox.showinfo("Build & Run", "Build system integration not implemented yet.")
+        root_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
+        subprocess.run(['make'], cwd=root_dir)
+        if self.filename:
+            subprocess.run([os.path.join(root_dir, 'tuxpad'), self.filename])
+        else:
+            messagebox.showinfo("Build & Run", "No file loaded to run.")
 
 
 def main():

--- a/scripts/editor_gui.py
+++ b/scripts/editor_gui.py
@@ -86,6 +86,9 @@ class TuxpadGUI:
 
         tools_menu = tk.Menu(menubar, tearoff=0)
         tools_menu.add_command(label="Highlight", command=self.highlight)
+        tools_menu.add_command(label="Spell Check", command=self.spell_check)
+        tools_menu.add_command(label="Format Python", command=self.auto_format)
+        tools_menu.add_command(label="Word Frequency", command=self.word_frequency)
         tools_menu.add_command(label="Preferences", command=self.preferences)
         tools_menu.add_command(label="Plugins", command=self.plugins)
         tools_menu.add_command(label="Build & Run", command=self.build_run)
@@ -129,6 +132,15 @@ class TuxpadGUI:
 
     def highlight(self):
         self.plugin_manager.run_plugin('highlight')
+
+    def spell_check(self):
+        self.plugin_manager.run_plugin('spellcheck')
+
+    def auto_format(self):
+        self.plugin_manager.run_plugin('autoformat')
+
+    def word_frequency(self):
+        self.plugin_manager.run_plugin('freq_plot')
 
     def preferences(self):
         messagebox.showinfo("Preferences", "Preferences dialog not implemented yet.")

--- a/scripts/editor_gui.py
+++ b/scripts/editor_gui.py
@@ -1,0 +1,99 @@
+import os
+import sys
+import subprocess
+import tkinter as tk
+from tkinter import filedialog, messagebox
+
+
+class TuxpadGUI:
+    def __init__(self, root):
+        self.root = root
+        root.title("Tuxpad GUI")
+        self.text = tk.Text(root, undo=True)
+        self.text.pack(expand=True, fill=tk.BOTH)
+        self.filename = None
+        self.create_menus()
+
+    def create_menus(self):
+        menubar = tk.Menu(self.root)
+
+        file_menu = tk.Menu(menubar, tearoff=0)
+        file_menu.add_command(label="New", command=self.new_file)
+        file_menu.add_command(label="Open", command=self.open_file)
+        file_menu.add_command(label="Save", command=self.save_file)
+        file_menu.add_separator()
+        file_menu.add_command(label="Close", command=self.root.quit)
+        menubar.add_cascade(label="File", menu=file_menu)
+
+        edit_menu = tk.Menu(menubar, tearoff=0)
+        edit_menu.add_command(label="Search", command=self.search)
+        edit_menu.add_command(label="Replace", command=self.replace)
+        edit_menu.add_command(label="Undo", command=self.text.edit_undo)
+        edit_menu.add_command(label="Redo", command=self.text.edit_redo)
+        menubar.add_cascade(label="Edit", menu=edit_menu)
+
+        tools_menu = tk.Menu(menubar, tearoff=0)
+        tools_menu.add_command(label="Highlight", command=self.highlight)
+        tools_menu.add_command(label="Preferences", command=self.preferences)
+        tools_menu.add_command(label="Plugins", command=self.plugins)
+        tools_menu.add_command(label="Build & Run", command=self.build_run)
+        menubar.add_cascade(label="Tools", menu=tools_menu)
+
+        self.root.config(menu=menubar)
+
+    def new_file(self):
+        self.text.delete('1.0', tk.END)
+        self.filename = None
+
+    def open_file(self):
+        fname = filedialog.askopenfilename()
+        if fname:
+            try:
+                with open(fname, 'r') as f:
+                    data = f.read()
+                self.text.delete('1.0', tk.END)
+                self.text.insert(tk.END, data)
+                self.filename = fname
+            except OSError:
+                messagebox.showerror("Error", f"Cannot open file {fname}")
+
+    def save_file(self):
+        if not self.filename:
+            fname = filedialog.asksaveasfilename()
+            if not fname:
+                return
+            self.filename = fname
+        try:
+            with open(self.filename, 'w') as f:
+                f.write(self.text.get('1.0', tk.END))
+        except OSError:
+            messagebox.showerror("Error", f"Cannot save file {self.filename}")
+
+    def search(self):
+        messagebox.showinfo("Search", "Search feature not implemented yet.")
+
+    def replace(self):
+        messagebox.showinfo("Replace", "Replace feature not implemented yet.")
+
+    def highlight(self):
+        script = os.path.join(os.path.dirname(__file__), 'highlight.py')
+        subprocess.run([sys.executable, script])
+
+    def preferences(self):
+        messagebox.showinfo("Preferences", "Preferences dialog not implemented yet.")
+
+    def plugins(self):
+        messagebox.showinfo("Plugins", "Plugin manager not implemented yet.")
+
+    def build_run(self):
+        messagebox.showinfo("Build & Run", "Build system integration not implemented yet.")
+
+
+def main():
+    root = tk.Tk()
+    app = TuxpadGUI(root)
+    root.mainloop()
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/highlight.py
+++ b/scripts/highlight.py
@@ -1,0 +1,2 @@
+print("Running Python plugin: highlight")
+# placeholder for syntax highlighting implementation

--- a/scripts/highlight.py
+++ b/scripts/highlight.py
@@ -1,2 +1,0 @@
-print("Running Python plugin: highlight")
-# placeholder for syntax highlighting implementation

--- a/src/editor_features.cpp
+++ b/src/editor_features.cpp
@@ -1,0 +1,16 @@
+#include "editor_features.h"
+#include <fstream>
+#include <string>
+
+int count_lines(const char *filename) {
+    std::ifstream file(filename);
+    if (!file.is_open()) {
+        return -1;
+    }
+    int lines = 0;
+    std::string line;
+    while (std::getline(file, line)) {
+        lines++;
+    }
+    return lines;
+}

--- a/src/editor_features.h
+++ b/src/editor_features.h
@@ -1,0 +1,14 @@
+#ifndef FEATURES_H
+#define FEATURES_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+int count_lines(const char *filename);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // FEATURES_H

--- a/src/main.c
+++ b/src/main.c
@@ -1,0 +1,23 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include "editor_features.h"
+
+int main(int argc, char **argv) {
+    if (argc < 2) {
+        printf("Usage: %s <file>\n", argv[0]);
+        return 1;
+    }
+    const char *filename = argv[1];
+    int lines = count_lines(filename);
+    if (lines >= 0) {
+        printf("File '%s' has %d lines.\n", filename, lines);
+    } else {
+        printf("Could not open file '%s'.\n", filename);
+        return 1;
+    }
+
+    // Launch the Python GUI demonstrating various editor tools
+    system("python3 scripts/editor_gui.py");
+
+    return 0;
+}


### PR DESCRIPTION
## Summary
- implement a Tkinter-based editor_gui.py exposing 12 tools
- launch the GUI from main.c
- document usage and tools in README
- add `make gui` target

## Testing
- `make`
- `./tuxpad README.md` *(fails: no $DISPLAY)*
- `python3 scripts/editor_gui.py` *(fails: no $DISPLAY)*
- `make gui` *(fails: no $DISPLAY)*
- `make clean`


------
https://chatgpt.com/codex/tasks/task_e_686410863a7c833088612a97505c3b63