### PR TITLE
Remove placeholder videos from ATF feed

### DIFF
--- a/auth.php
+++ b/auth.php
@@ -1,0 +1,57 @@
+<?php
+session_start();
+require_once __DIR__ . '/db.php';
+
+if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+    header('Location: index.php');
+    exit;
+}
+
+$action = $_POST['action'] ?? '';
+$username = trim($_POST['username'] ?? '');
+$password = $_POST['password'] ?? '';
+
+if ($username === '' || $password === '') {
+    header('Location: index.php?error=Please+fill+in+all+fields');
+    exit;
+}
+
+$db = get_db();
+
+if ($action === 'signup') {
+    $hash = password_hash($password, PASSWORD_DEFAULT);
+    $token = bin2hex(random_bytes(16));
+
+    $stmt = $db->prepare('INSERT INTO users (username, password_hash, qr_token) VALUES (:username, :password_hash, :qr_token)');
+    $stmt->bindValue(':username', $username, SQLITE3_TEXT);
+    $stmt->bindValue(':password_hash', $hash, SQLITE3_TEXT);
+    $stmt->bindValue(':qr_token', $token, SQLITE3_TEXT);
+
+    $result = @$stmt->execute();
+    if ($result === false) {
+        header('Location: index.php?error=Username+already+taken');
+        exit;
+    }
+
+    header('Location: index.php?success=1');
+    exit;
+}
+
+if ($action === 'login') {
+    $stmt = $db->prepare('SELECT id, password_hash FROM users WHERE username = :username');
+    $stmt->bindValue(':username', $username, SQLITE3_TEXT);
+    $result = $stmt->execute();
+    $user = $result->fetchArray(SQLITE3_ASSOC);
+
+    if (!$user || !password_verify($password, $user['password_hash'])) {
+        header('Location: index.php?error=Invalid+credentials');
+        exit;
+    }
+
+    $_SESSION['user_id'] = (int) $user['id'];
+    header('Location: index.php');
+    exit;
+}
+
+header('Location: index.php?error=Unknown+action');
+exit;

--- a/auth.php
+++ b/auth.php
@@ -3,7 +3,7 @@ session_start();
 require_once __DIR__ . '/db.php';
 
 if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
-    header('Location: index.php');
+    header('Location: login.php');
     exit;
 }
 
@@ -12,7 +12,8 @@ $username = trim($_POST['username'] ?? '');
 $password = $_POST['password'] ?? '';
 
 if ($username === '' || $password === '') {
-    header('Location: index.php?error=Please+fill+in+all+fields');
+    $target = $action === 'signup' ? 'signup.php' : 'login.php';
+    header('Location: ' . $target . '?error=Please+fill+in+all+fields');
     exit;
 }
 
@@ -29,11 +30,11 @@ if ($action === 'signup') {
 
     $result = @$stmt->execute();
     if ($result === false) {
-        header('Location: index.php?error=Username+already+taken');
+        header('Location: signup.php?error=Username+already+taken');
         exit;
     }
 
-    header('Location: index.php?success=1');
+    header('Location: login.php?success=1');
     exit;
 }
 
@@ -44,7 +45,7 @@ if ($action === 'login') {
     $user = $result->fetchArray(SQLITE3_ASSOC);
 
     if (!$user || !password_verify($password, $user['password_hash'])) {
-        header('Location: index.php?error=Invalid+credentials');
+        header('Location: login.php?error=Invalid+credentials');
         exit;
     }
 
@@ -53,5 +54,5 @@ if ($action === 'login') {
     exit;
 }
 
-header('Location: index.php?error=Unknown+action');
+header('Location: login.php?error=Unknown+action');
 exit;

--- a/auth.php
+++ b/auth.php
@@ -34,6 +34,12 @@ if ($action === 'signup') {
         exit;
     }
 
+    $userId = $db->lastInsertRowID();
+    $profileStmt = $db->prepare('INSERT OR IGNORE INTO profiles (user_id, display_name) VALUES (:user_id, :display_name)');
+    $profileStmt->bindValue(':user_id', $userId, SQLITE3_INTEGER);
+    $profileStmt->bindValue(':display_name', $username, SQLITE3_TEXT);
+    $profileStmt->execute();
+
     header('Location: login.php?success=1');
     exit;
 }

--- a/dashboard.php
+++ b/dashboard.php
@@ -1,0 +1,208 @@
+<?php
+session_start();
+require_once __DIR__ . '/db.php';
+
+$db = get_db();
+$user = null;
+
+if (isset($_SESSION['user_id'])) {
+    $stmt = $db->prepare('SELECT id, username, created_at FROM users WHERE id = :id');
+    $stmt->bindValue(':id', $_SESSION['user_id'], SQLITE3_INTEGER);
+    $result = $stmt->execute();
+    $user = $result->fetchArray(SQLITE3_ASSOC) ?: null;
+}
+
+if (!$user) {
+    header('Location: index.php?error=Please+log+in+to+view+dashboard');
+    exit;
+}
+
+$statsStmt = $db->prepare('SELECT COUNT(*) as video_count, COALESCE(SUM(views), 0) as total_views FROM videos WHERE user_id = :user_id');
+$statsStmt->bindValue(':user_id', $user['id'], SQLITE3_INTEGER);
+$statsResult = $statsStmt->execute();
+$stats = $statsResult->fetchArray(SQLITE3_ASSOC) ?: ['video_count' => 0, 'total_views' => 0];
+
+$recentStmt = $db->prepare('SELECT title, views, created_at FROM videos WHERE user_id = :user_id ORDER BY created_at DESC LIMIT 5');
+$recentStmt->bindValue(':user_id', $user['id'], SQLITE3_INTEGER);
+$recentResult = $recentStmt->execute();
+$recent = [];
+while ($row = $recentResult->fetchArray(SQLITE3_ASSOC)) {
+    $recent[] = $row;
+}
+
+$growth = [];
+for ($i = 6; $i >= 0; $i--) {
+    $date = date('Y-m-d', strtotime('-' . $i . ' days'));
+    $growthStmt = $db->prepare('SELECT COUNT(*) as count FROM videos WHERE user_id = :user_id AND date(created_at) = :date');
+    $growthStmt->bindValue(':user_id', $user['id'], SQLITE3_INTEGER);
+    $growthStmt->bindValue(':date', $date, SQLITE3_TEXT);
+    $growthResult = $growthStmt->execute();
+    $growthRow = $growthResult->fetchArray(SQLITE3_ASSOC);
+    $growth[] = ['date' => $date, 'count' => (int) $growthRow['count']];
+}
+?>
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>ATF Creator Dashboard</title>
+    <style>
+        :root {
+            --bg: #0f0f0f;
+            --card: #1c1c1c;
+            --muted: #aaaaaa;
+            --accent: #ff1a1a;
+            --text: #ffffff;
+            --outline: #2b2b2b;
+        }
+
+        * {
+            box-sizing: border-box;
+            font-family: "Inter", "Segoe UI", sans-serif;
+        }
+
+        body {
+            margin: 0;
+            background: var(--bg);
+            color: var(--text);
+        }
+
+        header {
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            padding: 18px 32px;
+            border-bottom: 1px solid var(--outline);
+        }
+
+        .pill {
+            padding: 8px 16px;
+            border-radius: 999px;
+            background: #232323;
+            border: 1px solid var(--outline);
+            color: var(--text);
+            text-decoration: none;
+            font-size: 14px;
+        }
+
+        main {
+            max-width: 1100px;
+            margin: 32px auto;
+            padding: 0 24px 48px;
+        }
+
+        .grid {
+            display: grid;
+            gap: 16px;
+            grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+        }
+
+        .card {
+            background: var(--card);
+            border-radius: 16px;
+            padding: 18px;
+            border: 1px solid var(--outline);
+        }
+
+        .muted {
+            color: var(--muted);
+            font-size: 13px;
+        }
+
+        .chart {
+            display: grid;
+            gap: 8px;
+        }
+
+        .bar {
+            background: #232323;
+            border-radius: 999px;
+            overflow: hidden;
+        }
+
+        .bar span {
+            display: block;
+            height: 10px;
+            background: var(--accent);
+        }
+
+        table {
+            width: 100%;
+            border-collapse: collapse;
+            font-size: 14px;
+        }
+
+        th, td {
+            text-align: left;
+            padding: 8px 0;
+            border-bottom: 1px solid var(--outline);
+        }
+    </style>
+</head>
+<body>
+<header>
+    <strong>ATF Creator Dashboard</strong>
+    <div>
+        <a class="pill" href="index.php">Home</a>
+        <a class="pill" href="upload.php">Upload</a>
+        <a class="pill" href="library.php">Library</a>
+        <a class="pill" href="settings.php">Settings</a>
+    </div>
+</header>
+<main>
+    <div class="grid">
+        <div class="card">
+            <h3>Total uploads</h3>
+            <p><?php echo number_format((int) $stats['video_count']); ?> videos</p>
+            <p class="muted">Since <?php echo htmlspecialchars(date('M Y', strtotime($user['created_at']))); ?></p>
+        </div>
+        <div class="card">
+            <h3>Total views</h3>
+            <p><?php echo number_format((int) $stats['total_views']); ?> views</p>
+            <p class="muted">Lifetime performance</p>
+        </div>
+        <div class="card">
+            <h3>Weekly uploads</h3>
+            <div class="chart">
+                <?php $max = max(array_column($growth, 'count')) ?: 1; ?>
+                <?php foreach ($growth as $day): ?>
+                    <div>
+                        <span class="muted"><?php echo htmlspecialchars(date('D', strtotime($day['date']))); ?></span>
+                        <div class="bar"><span style="width: <?php echo (int) (($day['count'] / $max) * 100); ?>%"></span></div>
+                    </div>
+                <?php endforeach; ?>
+            </div>
+        </div>
+    </div>
+
+    <div class="card" style="margin-top: 24px;">
+        <h3>Recent uploads</h3>
+        <table>
+            <thead>
+                <tr>
+                    <th>Title</th>
+                    <th>Views</th>
+                    <th>Date</th>
+                </tr>
+            </thead>
+            <tbody>
+                <?php if (count($recent) === 0): ?>
+                    <tr>
+                        <td colspan="3" class="muted">No uploads yet.</td>
+                    </tr>
+                <?php else: ?>
+                    <?php foreach ($recent as $video): ?>
+                        <tr>
+                            <td><?php echo htmlspecialchars($video['title']); ?></td>
+                            <td><?php echo number_format((int) $video['views']); ?></td>
+                            <td><?php echo htmlspecialchars(date('M j, Y', strtotime($video['created_at']))); ?></td>
+                        </tr>
+                    <?php endforeach; ?>
+                <?php endif; ?>
+            </tbody>
+        </table>
+    </div>
+</main>
+</body>
+</html>

--- a/dashboard.php
+++ b/dashboard.php
@@ -40,6 +40,14 @@ for ($i = 6; $i >= 0; $i--) {
     $growthRow = $growthResult->fetchArray(SQLITE3_ASSOC);
     $growth[] = ['date' => $date, 'count' => (int) $growthRow['count']];
 }
+
+$notifStmt = $db->prepare('SELECT title, body, created_at FROM notifications WHERE user_id = :user_id ORDER BY created_at DESC LIMIT 3');
+$notifStmt->bindValue(':user_id', $user['id'], SQLITE3_INTEGER);
+$notifResult = $notifStmt->execute();
+$notifications = [];
+while ($row = $notifResult->fetchArray(SQLITE3_ASSOC)) {
+    $notifications[] = $row;
+}
 ?>
 <!doctype html>
 <html lang="en">
@@ -98,6 +106,14 @@ for ($i = 6; $i >= 0; $i--) {
             grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
         }
 
+        .hero {
+            background: linear-gradient(135deg, rgba(255, 26, 26, 0.18), rgba(255, 255, 255, 0.05));
+            border-radius: 20px;
+            padding: 24px;
+            border: 1px solid rgba(255, 255, 255, 0.08);
+            margin-bottom: 20px;
+        }
+
         .card {
             background: var(--card);
             border-radius: 16px;
@@ -127,6 +143,18 @@ for ($i = 6; $i >= 0; $i--) {
             background: var(--accent);
         }
 
+        .notif {
+            display: grid;
+            gap: 8px;
+        }
+
+        .notif-item {
+            padding: 12px;
+            border-radius: 12px;
+            background: #181818;
+            border: 1px solid var(--outline);
+        }
+
         table {
             width: 100%;
             border-collapse: collapse;
@@ -151,6 +179,10 @@ for ($i = 6; $i >= 0; $i--) {
     </div>
 </header>
 <main>
+    <div class="hero">
+        <h2>Creator dashboard</h2>
+        <p class="muted">Track your uploads, momentum, and audience impact.</p>
+    </div>
     <div class="grid">
         <div class="card">
             <h3>Total uploads</h3>
@@ -173,6 +205,23 @@ for ($i = 6; $i >= 0; $i--) {
                     </div>
                 <?php endforeach; ?>
             </div>
+        </div>
+    </div>
+
+    <div class="card" style="margin-top: 24px;">
+        <h3>Creator notifications</h3>
+        <div class="notif">
+            <?php if (count($notifications) === 0): ?>
+                <div class="notif-item muted">No updates yet. Upload to trigger new insights.</div>
+            <?php else: ?>
+                <?php foreach ($notifications as $note): ?>
+                    <div class="notif-item">
+                        <strong><?php echo htmlspecialchars($note['title']); ?></strong>
+                        <p class="muted"><?php echo htmlspecialchars($note['body']); ?></p>
+                        <span class="muted"><?php echo htmlspecialchars(date('M j, Y', strtotime($note['created_at']))); ?></span>
+                    </div>
+                <?php endforeach; ?>
+            <?php endif; ?>
         </div>
     </div>
 

--- a/db.php
+++ b/db.php
@@ -1,0 +1,19 @@
+<?php
+$databasePath = __DIR__ . '/atf.sqlite';
+
+function get_db(): SQLite3
+{
+    global $databasePath;
+
+    $db = new SQLite3($databasePath);
+    $db->exec('PRAGMA foreign_keys = ON');
+
+    $db->exec('CREATE TABLE IF NOT EXISTS users (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        username TEXT UNIQUE NOT NULL,
+        password_hash TEXT NOT NULL,
+        qr_token TEXT UNIQUE NOT NULL
+    )');
+
+    return $db;
+}

--- a/db.php
+++ b/db.php
@@ -16,6 +16,15 @@ function get_db(): SQLite3
         created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
     )');
 
+    $db->exec('CREATE TABLE IF NOT EXISTS profiles (
+        user_id INTEGER PRIMARY KEY,
+        display_name TEXT NOT NULL DEFAULT "",
+        bio TEXT NOT NULL DEFAULT "",
+        location TEXT NOT NULL DEFAULT "",
+        theme TEXT NOT NULL DEFAULT "midnight",
+        FOREIGN KEY (user_id) REFERENCES users (id) ON DELETE CASCADE
+    )');
+
     $db->exec('CREATE TABLE IF NOT EXISTS videos (
         id INTEGER PRIMARY KEY AUTOINCREMENT,
         user_id INTEGER NOT NULL,
@@ -23,6 +32,15 @@ function get_db(): SQLite3
         description TEXT NOT NULL,
         category TEXT NOT NULL,
         views INTEGER NOT NULL DEFAULT 0,
+        created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+        FOREIGN KEY (user_id) REFERENCES users (id) ON DELETE CASCADE
+    )');
+
+    $db->exec('CREATE TABLE IF NOT EXISTS notifications (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        user_id INTEGER NOT NULL,
+        title TEXT NOT NULL,
+        body TEXT NOT NULL,
         created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
         FOREIGN KEY (user_id) REFERENCES users (id) ON DELETE CASCADE
     )');

--- a/db.php
+++ b/db.php
@@ -12,7 +12,19 @@ function get_db(): SQLite3
         id INTEGER PRIMARY KEY AUTOINCREMENT,
         username TEXT UNIQUE NOT NULL,
         password_hash TEXT NOT NULL,
-        qr_token TEXT UNIQUE NOT NULL
+        qr_token TEXT UNIQUE NOT NULL,
+        created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+    )');
+
+    $db->exec('CREATE TABLE IF NOT EXISTS videos (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        user_id INTEGER NOT NULL,
+        title TEXT NOT NULL,
+        description TEXT NOT NULL,
+        category TEXT NOT NULL,
+        views INTEGER NOT NULL DEFAULT 0,
+        created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+        FOREIGN KEY (user_id) REFERENCES users (id) ON DELETE CASCADE
     )');
 
     return $db;

--- a/index.php
+++ b/index.php
@@ -334,7 +334,8 @@ if ($user) {
             <span class="pill">Hi, <?php echo htmlspecialchars($user['username']); ?></span>
             <a class="pill" href="logout.php">Logout</a>
         <?php else: ?>
-            <span class="pill">Guest</span>
+            <a class="pill" href="login.php">Log in</a>
+            <a class="pill" href="signup.php">Sign up</a>
         <?php endif; ?>
     </div>
 </header>
@@ -362,8 +363,7 @@ if ($user) {
         <?php if ($user): ?>
             <div class="nav-card qr-card">
                 <h3>Login on your phone</h3>
-                <p class="muted">Scan this QR code to sign in instantly.</p>
-                <img src="https://chart.googleapis.com/chart?chs=200x200&cht=qr&chl=<?php echo urlencode($qrLoginUrl); ?>" alt="QR code for login">
+                <p class="muted">Use your secure login link on any device.</p>
                 <p class="muted">Link: <?php echo htmlspecialchars($qrLoginUrl); ?></p>
             </div>
         <?php endif; ?>
@@ -411,29 +411,15 @@ if ($user) {
 
             <?php if (!$user): ?>
                 <div>
-                    <h3>Log in</h3>
-                    <form method="post" action="auth.php">
-                        <input type="hidden" name="action" value="login">
-                        <label>Username</label>
-                        <input type="text" name="username" required>
-                        <label>Password</label>
-                        <input type="password" name="password" required>
-                        <button type="submit">Log in</button>
-                    </form>
-                </div>
-                <div>
-                    <h3>Create an account</h3>
-                    <form method="post" action="auth.php">
-                        <input type="hidden" name="action" value="signup">
-                        <label>Username</label>
-                        <input type="text" name="username" required>
-                        <label>Password</label>
-                        <input type="password" name="password" required>
-                        <button type="submit">Sign up</button>
-                    </form>
+                    <h3>Log in or create an account</h3>
+                    <p class="muted">Use the dedicated pages for a focused sign-in experience.</p>
+                    <p>
+                        <a class="pill" href="login.php">Log in</a>
+                        <a class="pill" href="signup.php">Sign up</a>
+                    </p>
                 </div>
             <?php else: ?>
-                <p class="muted">You are signed in. Use the QR code to log in on another phone or tablet.</p>
+                <p class="muted">You are signed in. Use the secure link in Settings to log in on another device.</p>
             <?php endif; ?>
         </div>
     </section>

--- a/index.php
+++ b/index.php
@@ -1,0 +1,429 @@
+<?php
+session_start();
+require_once __DIR__ . '/db.php';
+
+$db = get_db();
+$user = null;
+
+if (isset($_SESSION['user_id'])) {
+    $stmt = $db->prepare('SELECT id, username, qr_token FROM users WHERE id = :id');
+    $stmt->bindValue(':id', $_SESSION['user_id'], SQLITE3_INTEGER);
+    $result = $stmt->execute();
+    $user = $result->fetchArray(SQLITE3_ASSOC) ?: null;
+}
+
+$videos = [];
+
+$qrLoginUrl = null;
+if ($user) {
+    $qrLoginUrl = sprintf('%s://%s%s/qr_login.php?token=%s',
+        (!empty($_SERVER['HTTPS']) && $_SERVER['HTTPS'] !== 'off') ? 'https' : 'http',
+        $_SERVER['HTTP_HOST'],
+        rtrim(dirname($_SERVER['PHP_SELF']), '/'),
+        urlencode($user['qr_token'])
+    );
+}
+?>
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>ATF | Media Platform</title>
+    <style>
+        :root {
+            color-scheme: light;
+            --bg: #0f0f0f;
+            --card: #1c1c1c;
+            --muted: #aaaaaa;
+            --accent: #ff1a1a;
+            --text: #ffffff;
+            --outline: #2b2b2b;
+        }
+
+        * {
+            box-sizing: border-box;
+            font-family: "Inter", "Segoe UI", sans-serif;
+            margin: 0;
+            padding: 0;
+        }
+
+        body {
+            background: var(--bg);
+            color: var(--text);
+            min-height: 100vh;
+        }
+
+        header {
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            padding: 18px 32px;
+            border-bottom: 1px solid var(--outline);
+            position: sticky;
+            top: 0;
+            background: rgba(15, 15, 15, 0.92);
+            backdrop-filter: blur(12px);
+            z-index: 10;
+        }
+
+        .brand {
+            display: flex;
+            gap: 12px;
+            align-items: center;
+        }
+
+        .logo {
+            width: 40px;
+            height: 40px;
+            border-radius: 12px;
+            background: var(--accent);
+            display: grid;
+            place-items: center;
+            font-weight: 700;
+            font-size: 18px;
+        }
+
+        .search {
+            flex: 1;
+            max-width: 520px;
+            margin: 0 32px;
+            display: flex;
+            align-items: center;
+            background: #181818;
+            border-radius: 999px;
+            padding: 10px 18px;
+            border: 1px solid var(--outline);
+        }
+
+        .search input {
+            background: transparent;
+            border: none;
+            color: var(--text);
+            width: 100%;
+            font-size: 15px;
+            outline: none;
+        }
+
+        .header-actions {
+            display: flex;
+            gap: 16px;
+            align-items: center;
+        }
+
+        .pill {
+            padding: 8px 16px;
+            border-radius: 999px;
+            background: #232323;
+            border: 1px solid var(--outline);
+            color: var(--text);
+            text-decoration: none;
+            font-size: 14px;
+        }
+
+        main {
+            display: grid;
+            grid-template-columns: 260px 1fr;
+            gap: 24px;
+            padding: 28px 32px 48px;
+        }
+
+        aside {
+            display: flex;
+            flex-direction: column;
+            gap: 16px;
+        }
+
+        .nav-card {
+            background: var(--card);
+            padding: 18px;
+            border-radius: 16px;
+            border: 1px solid var(--outline);
+        }
+
+        .nav-card h3 {
+            margin-bottom: 12px;
+            font-size: 15px;
+        }
+
+        .nav-card ul {
+            list-style: none;
+            display: grid;
+            gap: 10px;
+            color: var(--muted);
+            font-size: 14px;
+        }
+
+        .content-header {
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            margin-bottom: 24px;
+        }
+
+        .content-header h2 {
+            font-size: 24px;
+        }
+
+        .grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
+            gap: 20px;
+        }
+
+        .video-card {
+            background: var(--card);
+            border-radius: 18px;
+            overflow: hidden;
+            border: 1px solid var(--outline);
+            transition: transform 0.2s ease, box-shadow 0.2s ease;
+        }
+
+        .video-card:hover {
+            transform: translateY(-4px);
+            box-shadow: 0 12px 30px rgba(0, 0, 0, 0.35);
+        }
+
+        .thumb {
+            height: 150px;
+            background: linear-gradient(135deg, #2b2b2b, #3a1a1a);
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            font-weight: 600;
+        }
+
+        .video-info {
+            padding: 16px;
+            display: grid;
+            gap: 6px;
+        }
+
+        .video-info h4 {
+            font-size: 15px;
+        }
+
+        .video-meta {
+            color: var(--muted);
+            font-size: 13px;
+        }
+
+        .empty-state {
+            background: var(--card);
+            border-radius: 18px;
+            border: 1px dashed var(--outline);
+            padding: 32px;
+            text-align: center;
+            color: var(--muted);
+        }
+
+        .auth-card {
+            background: var(--card);
+            border-radius: 16px;
+            padding: 20px;
+            border: 1px solid var(--outline);
+            display: grid;
+            gap: 16px;
+        }
+
+        .auth-card h3 {
+            font-size: 16px;
+        }
+
+        .auth-card form {
+            display: grid;
+            gap: 12px;
+        }
+
+        label {
+            font-size: 13px;
+            color: var(--muted);
+        }
+
+        input[type="text"],
+        input[type="password"] {
+            padding: 10px 12px;
+            border-radius: 10px;
+            border: 1px solid var(--outline);
+            background: #141414;
+            color: var(--text);
+        }
+
+        button {
+            padding: 10px 14px;
+            border-radius: 10px;
+            border: none;
+            background: var(--accent);
+            color: #fff;
+            font-weight: 600;
+            cursor: pointer;
+        }
+
+        .qr-card {
+            display: grid;
+            gap: 12px;
+            text-align: center;
+        }
+
+        .qr-card img {
+            width: 180px;
+            height: 180px;
+            border-radius: 12px;
+            border: 1px solid var(--outline);
+            background: #fff;
+        }
+
+        .success {
+            color: #6ee7b7;
+            font-size: 13px;
+        }
+
+        .error {
+            color: #fca5a5;
+            font-size: 13px;
+        }
+
+        .muted {
+            color: var(--muted);
+            font-size: 13px;
+        }
+
+        @media (max-width: 960px) {
+            main {
+                grid-template-columns: 1fr;
+            }
+
+            header {
+                flex-wrap: wrap;
+                gap: 16px;
+            }
+
+            .search {
+                order: 3;
+                margin: 0;
+                width: 100%;
+            }
+        }
+    </style>
+</head>
+<body>
+<header>
+    <div class="brand">
+        <div class="logo">ATF</div>
+        <div>
+            <strong>ATF Media</strong><br>
+            <span class="muted">Stream. Create. Connect.</span>
+        </div>
+    </div>
+    <div class="search">
+        <input type="text" placeholder="Search videos, creators, or topics...">
+    </div>
+    <div class="header-actions">
+        <?php if ($user): ?>
+            <span class="pill">Hi, <?php echo htmlspecialchars($user['username']); ?></span>
+            <a class="pill" href="logout.php">Logout</a>
+        <?php else: ?>
+            <span class="pill">Guest</span>
+        <?php endif; ?>
+    </div>
+</header>
+<main>
+    <aside>
+        <div class="nav-card">
+            <h3>Quick Access</h3>
+            <ul>
+                <li>Home Feed</li>
+                <li>Trending Now</li>
+                <li>Subscriptions</li>
+                <li>ATF Originals</li>
+                <li>Watch Later</li>
+            </ul>
+        </div>
+        <div class="nav-card">
+            <h3>Creator Tools</h3>
+            <ul>
+                <li>Upload Studio</li>
+                <li>Live Control Room</li>
+                <li>Analytics</li>
+                <li>Brand Collaborations</li>
+            </ul>
+        </div>
+        <?php if ($user): ?>
+            <div class="nav-card qr-card">
+                <h3>Login on your phone</h3>
+                <p class="muted">Scan this QR code to sign in instantly.</p>
+                <img src="https://chart.googleapis.com/chart?chs=200x200&cht=qr&chl=<?php echo urlencode($qrLoginUrl); ?>" alt="QR code for login">
+                <p class="muted">Link: <?php echo htmlspecialchars($qrLoginUrl); ?></p>
+            </div>
+        <?php endif; ?>
+    </aside>
+
+    <section>
+        <div class="content-header">
+            <h2>ATF Home</h2>
+            <span class="muted">Personalized for you</span>
+        </div>
+        <div class="grid">
+            <?php if (count($videos) === 0): ?>
+                <div class="empty-state">
+                    <h4>No videos yet</h4>
+                    <p>Start uploading to build your ATF library.</p>
+                </div>
+            <?php else: ?>
+                <?php foreach ($videos as $index => $video): ?>
+                    <article class="video-card">
+                        <div class="thumb">ATF Video <?php echo $index + 1; ?></div>
+                        <div class="video-info">
+                            <h4><?php echo htmlspecialchars($video['title']); ?></h4>
+                            <div class="video-meta"><?php echo htmlspecialchars($video['creator']); ?></div>
+                            <div class="video-meta"><?php echo htmlspecialchars($video['views']); ?> · <?php echo htmlspecialchars($video['time']); ?></div>
+                        </div>
+                    </article>
+                <?php endforeach; ?>
+            <?php endif; ?>
+        </div>
+    </section>
+
+    <section>
+        <div class="content-header">
+            <h2><?php echo $user ? 'Welcome back' : 'Join ATF'; ?></h2>
+            <span class="muted">Secure login & signup</span>
+        </div>
+        <div class="auth-card">
+            <?php if (isset($_GET['success'])): ?>
+                <div class="success">Account created! You can log in now.</div>
+            <?php elseif (isset($_GET['error'])): ?>
+                <div class="error"><?php echo htmlspecialchars($_GET['error']); ?></div>
+            <?php endif; ?>
+
+            <?php if (!$user): ?>
+                <div>
+                    <h3>Log in</h3>
+                    <form method="post" action="auth.php">
+                        <input type="hidden" name="action" value="login">
+                        <label>Username</label>
+                        <input type="text" name="username" required>
+                        <label>Password</label>
+                        <input type="password" name="password" required>
+                        <button type="submit">Log in</button>
+                    </form>
+                </div>
+                <div>
+                    <h3>Create an account</h3>
+                    <form method="post" action="auth.php">
+                        <input type="hidden" name="action" value="signup">
+                        <label>Username</label>
+                        <input type="text" name="username" required>
+                        <label>Password</label>
+                        <input type="password" name="password" required>
+                        <button type="submit">Sign up</button>
+                    </form>
+                </div>
+            <?php else: ?>
+                <p class="muted">You are signed in. Use the QR code to log in on another phone or tablet.</p>
+            <?php endif; ?>
+        </div>
+    </section>
+</main>
+</body>
+</html>

--- a/index.php
+++ b/index.php
@@ -6,18 +6,30 @@ $db = get_db();
 $user = null;
 
 if (isset($_SESSION['user_id'])) {
-    $stmt = $db->prepare('SELECT id, username, qr_token FROM users WHERE id = :id');
+    $stmt = $db->prepare('SELECT users.id, users.username, users.qr_token, profiles.display_name FROM users LEFT JOIN profiles ON users.id = profiles.user_id WHERE users.id = :id');
     $stmt->bindValue(':id', $_SESSION['user_id'], SQLITE3_INTEGER);
     $result = $stmt->execute();
     $user = $result->fetchArray(SQLITE3_ASSOC) ?: null;
 }
 
 $videos = [];
-$videoStmt = $db->prepare('SELECT videos.id, videos.title, videos.description, videos.views, videos.created_at, users.username FROM videos JOIN users ON videos.user_id = users.id ORDER BY videos.created_at DESC LIMIT 8');
+$videoStmt = $db->prepare('SELECT videos.id, videos.title, videos.description, videos.category, videos.views, videos.created_at, users.username FROM videos JOIN users ON videos.user_id = users.id ORDER BY videos.created_at DESC LIMIT 8');
 $videoResult = $videoStmt->execute();
 while ($row = $videoResult->fetchArray(SQLITE3_ASSOC)) {
     $videos[] = $row;
 }
+
+$userStats = null;
+if ($user) {
+    $statsStmt = $db->prepare('SELECT COUNT(*) as video_count, COALESCE(SUM(views), 0) as total_views FROM videos WHERE user_id = :user_id');
+    $statsStmt->bindValue(':user_id', $user['id'], SQLITE3_INTEGER);
+    $statsResult = $statsStmt->execute();
+    $userStats = $statsResult->fetchArray(SQLITE3_ASSOC) ?: ['video_count' => 0, 'total_views' => 0];
+}
+
+$platformStmt = $db->prepare('SELECT (SELECT COUNT(*) FROM users) as creators, (SELECT COUNT(*) FROM videos) as uploads');
+$platformResult = $platformStmt->execute();
+$platformStats = $platformResult->fetchArray(SQLITE3_ASSOC) ?: ['creators' => 0, 'uploads' => 0];
 
 $qrLoginUrl = null;
 if ($user) {
@@ -124,6 +136,69 @@ if ($user) {
             color: var(--text);
             text-decoration: none;
             font-size: 14px;
+        }
+
+        .pill.soft {
+            background: rgba(255, 255, 255, 0.06);
+            border-color: rgba(255, 255, 255, 0.08);
+        }
+
+        .hero-card {
+            background: linear-gradient(135deg, rgba(255, 26, 26, 0.18), rgba(255, 255, 255, 0.04));
+            border-radius: 20px;
+            padding: 24px;
+            border: 1px solid rgba(255, 255, 255, 0.08);
+            display: grid;
+            gap: 12px;
+        }
+
+        .hero-card h1 {
+            font-size: 28px;
+        }
+
+        .hero-card p {
+            color: var(--muted);
+            line-height: 1.5;
+        }
+
+        .stat-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+            gap: 16px;
+            margin: 16px 0 24px;
+        }
+
+        .stat-card {
+            background: var(--card);
+            border-radius: 16px;
+            padding: 16px;
+            border: 1px solid var(--outline);
+            display: grid;
+            gap: 6px;
+        }
+
+        .stat-card strong {
+            font-size: 20px;
+        }
+
+        .tag-list {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 8px;
+        }
+
+        .chip {
+            padding: 6px 12px;
+            border-radius: 999px;
+            background: #1a1a1a;
+            border: 1px solid var(--outline);
+            color: var(--muted);
+            font-size: 12px;
+        }
+
+        .section-stack {
+            display: grid;
+            gap: 20px;
         }
 
         main {
@@ -331,7 +406,7 @@ if ($user) {
     </div>
     <div class="header-actions">
         <?php if ($user): ?>
-            <span class="pill">Hi, <?php echo htmlspecialchars($user['username']); ?></span>
+            <span class="pill">Hi, <?php echo htmlspecialchars(($user['display_name'] ?? '') !== '' ? $user['display_name'] : $user['username']); ?></span>
             <a class="pill" href="logout.php">Logout</a>
         <?php else: ?>
             <a class="pill" href="login.php">Log in</a>
@@ -360,16 +435,62 @@ if ($user) {
                 <li><a class="pill" href="settings.php">Account Settings</a></li>
             </ul>
         </div>
+        <div class="nav-card">
+            <h3>Trending tags</h3>
+            <div class="tag-list">
+                <span class="chip">#ATFOriginals</span>
+                <span class="chip">#CreatorSprint</span>
+                <span class="chip">#LiveCoding</span>
+                <span class="chip">#StudioTips</span>
+                <span class="chip">#DailyUpload</span>
+            </div>
+        </div>
         <?php if ($user): ?>
             <div class="nav-card qr-card">
                 <h3>Login on your phone</h3>
                 <p class="muted">Use your secure login link on any device.</p>
                 <p class="muted">Link: <?php echo htmlspecialchars($qrLoginUrl); ?></p>
             </div>
+            <div class="nav-card">
+                <h3>Creator pulse</h3>
+                <p class="muted">Your creator stats this month.</p>
+                <div class="stat-grid">
+                    <div class="stat-card">
+                        <span class="muted">Uploads</span>
+                        <strong><?php echo number_format((int) $userStats['video_count']); ?></strong>
+                    </div>
+                    <div class="stat-card">
+                        <span class="muted">Views</span>
+                        <strong><?php echo number_format((int) $userStats['total_views']); ?></strong>
+                    </div>
+                </div>
+            </div>
         <?php endif; ?>
     </aside>
 
-    <section>
+    <section class="section-stack">
+        <div class="hero-card">
+            <h1>Welcome to ATF Media</h1>
+            <p>Build your channel, ship videos fast, and keep your audience engaged with next-level creator tools.</p>
+            <div>
+                <a class="pill" href="upload.php">Start uploading</a>
+                <a class="pill soft" href="library.php">Manage library</a>
+            </div>
+        </div>
+        <div class="stat-grid">
+            <div class="stat-card">
+                <span class="muted">Active creators</span>
+                <strong><?php echo number_format((int) $platformStats['creators']); ?></strong>
+            </div>
+            <div class="stat-card">
+                <span class="muted">New uploads</span>
+                <strong><?php echo number_format((int) $platformStats['uploads']); ?></strong>
+            </div>
+            <div class="stat-card">
+                <span class="muted">Categories</span>
+                <strong>6</strong>
+            </div>
+        </div>
         <div class="content-header">
             <h2>ATF Home</h2>
             <span class="muted">Personalized for you</span>
@@ -389,7 +510,7 @@ if ($user) {
                             <h4><?php echo htmlspecialchars($video['title']); ?></h4>
                             <div class="video-meta">by <?php echo htmlspecialchars($video['username']); ?></div>
                             <div class="video-desc"><?php echo htmlspecialchars($video['description']); ?></div>
-                            <div class="video-meta"><?php echo number_format((int) $video['views']); ?> views · <?php echo htmlspecialchars(date('M j, Y', strtotime($video['created_at']))); ?></div>
+                            <div class="video-meta"><?php echo htmlspecialchars($video['category']); ?> · <?php echo number_format((int) $video['views']); ?> views · <?php echo htmlspecialchars(date('M j, Y', strtotime($video['created_at']))); ?></div>
                         </div>
                     </article>
                 <?php endforeach; ?>

--- a/index.php
+++ b/index.php
@@ -13,6 +13,11 @@ if (isset($_SESSION['user_id'])) {
 }
 
 $videos = [];
+$videoStmt = $db->prepare('SELECT videos.id, videos.title, videos.description, videos.views, videos.created_at, users.username FROM videos JOIN users ON videos.user_id = users.id ORDER BY videos.created_at DESC LIMIT 8');
+$videoResult = $videoStmt->execute();
+while ($row = $videoResult->fetchArray(SQLITE3_ASSOC)) {
+    $videos[] = $row;
+}
 
 $qrLoginUrl = null;
 if ($user) {
@@ -208,6 +213,12 @@ if ($user) {
             font-size: 13px;
         }
 
+        .video-desc {
+            font-size: 12px;
+            color: #cfcfcf;
+            line-height: 1.4;
+        }
+
         .empty-state {
             background: var(--card);
             border-radius: 18px;
@@ -342,10 +353,10 @@ if ($user) {
         <div class="nav-card">
             <h3>Creator Tools</h3>
             <ul>
-                <li>Upload Studio</li>
-                <li>Live Control Room</li>
-                <li>Analytics</li>
-                <li>Brand Collaborations</li>
+                <li><a class="pill" href="upload.php">Upload Studio</a></li>
+                <li><a class="pill" href="library.php">Video Library</a></li>
+                <li><a class="pill" href="dashboard.php">Creator Dashboard</a></li>
+                <li><a class="pill" href="settings.php">Account Settings</a></li>
             </ul>
         </div>
         <?php if ($user): ?>
@@ -368,6 +379,7 @@ if ($user) {
                 <div class="empty-state">
                     <h4>No videos yet</h4>
                     <p>Start uploading to build your ATF library.</p>
+                    <p><a class="pill" href="upload.php">Upload your first video</a></p>
                 </div>
             <?php else: ?>
                 <?php foreach ($videos as $index => $video): ?>
@@ -375,8 +387,9 @@ if ($user) {
                         <div class="thumb">ATF Video <?php echo $index + 1; ?></div>
                         <div class="video-info">
                             <h4><?php echo htmlspecialchars($video['title']); ?></h4>
-                            <div class="video-meta"><?php echo htmlspecialchars($video['creator']); ?></div>
-                            <div class="video-meta"><?php echo htmlspecialchars($video['views']); ?> · <?php echo htmlspecialchars($video['time']); ?></div>
+                            <div class="video-meta">by <?php echo htmlspecialchars($video['username']); ?></div>
+                            <div class="video-desc"><?php echo htmlspecialchars($video['description']); ?></div>
+                            <div class="video-meta"><?php echo number_format((int) $video['views']); ?> views · <?php echo htmlspecialchars(date('M j, Y', strtotime($video['created_at']))); ?></div>
                         </div>
                     </article>
                 <?php endforeach; ?>

--- a/library.php
+++ b/library.php
@@ -46,6 +46,11 @@ $videos = [];
 while ($row = $result->fetchArray(SQLITE3_ASSOC)) {
     $videos[] = $row;
 }
+
+$summaryStmt = $db->prepare('SELECT COUNT(*) as total_videos, COALESCE(SUM(views), 0) as total_views FROM videos WHERE user_id = :user_id');
+$summaryStmt->bindValue(':user_id', $user['id'], SQLITE3_INTEGER);
+$summaryResult = $summaryStmt->execute();
+$summary = $summaryResult->fetchArray(SQLITE3_ASSOC) ?: ['total_videos' => 0, 'total_views' => 0];
 ?>
 <!doctype html>
 <html lang="en">
@@ -105,6 +110,26 @@ while ($row = $result->fetchArray(SQLITE3_ASSOC)) {
             margin-bottom: 20px;
         }
 
+        .summary {
+            display: grid;
+            gap: 16px;
+            grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+            margin-bottom: 20px;
+        }
+
+        .summary-card {
+            background: var(--card);
+            border-radius: 16px;
+            padding: 16px;
+            border: 1px solid var(--outline);
+            display: grid;
+            gap: 6px;
+        }
+
+        .summary-card strong {
+            font-size: 20px;
+        }
+
         input, select {
             padding: 10px 12px;
             border-radius: 10px;
@@ -154,6 +179,20 @@ while ($row = $result->fetchArray(SQLITE3_ASSOC)) {
 </header>
 <main>
     <p class="muted">Showing videos for <?php echo htmlspecialchars($user['username']); ?></p>
+    <div class="summary">
+        <div class="summary-card">
+            <span class="muted">Total videos</span>
+            <strong><?php echo number_format((int) $summary['total_videos']); ?></strong>
+        </div>
+        <div class="summary-card">
+            <span class="muted">Total views</span>
+            <strong><?php echo number_format((int) $summary['total_views']); ?></strong>
+        </div>
+        <div class="summary-card">
+            <span class="muted">Current filter</span>
+            <strong><?php echo $category === '' ? 'All' : htmlspecialchars($category); ?></strong>
+        </div>
+    </div>
     <form class="filters" method="get">
         <input type="text" name="search" placeholder="Search by title or description" value="<?php echo htmlspecialchars($search); ?>">
         <select name="category">

--- a/library.php
+++ b/library.php
@@ -1,0 +1,186 @@
+<?php
+session_start();
+require_once __DIR__ . '/db.php';
+
+$db = get_db();
+$user = null;
+
+if (isset($_SESSION['user_id'])) {
+    $stmt = $db->prepare('SELECT id, username FROM users WHERE id = :id');
+    $stmt->bindValue(':id', $_SESSION['user_id'], SQLITE3_INTEGER);
+    $result = $stmt->execute();
+    $user = $result->fetchArray(SQLITE3_ASSOC) ?: null;
+}
+
+if (!$user) {
+    header('Location: index.php?error=Please+log+in+to+view+your+library');
+    exit;
+}
+
+$search = trim($_GET['search'] ?? '');
+$category = trim($_GET['category'] ?? '');
+$categories = ['','Tech', 'Music', 'Education', 'Gaming', 'Lifestyle', 'Sports'];
+
+$query = 'SELECT id, title, description, category, views, created_at FROM videos WHERE user_id = :user_id';
+$params = [':user_id' => $user['id']];
+
+if ($search !== '') {
+    $query .= ' AND (title LIKE :search OR description LIKE :search)';
+    $params[':search'] = '%' . $search . '%';
+}
+
+if ($category !== '') {
+    $query .= ' AND category = :category';
+    $params[':category'] = $category;
+}
+
+$query .= ' ORDER BY created_at DESC';
+
+$stmt = $db->prepare($query);
+foreach ($params as $key => $value) {
+    $stmt->bindValue($key, $value, is_int($value) ? SQLITE3_INTEGER : SQLITE3_TEXT);
+}
+
+$result = $stmt->execute();
+$videos = [];
+while ($row = $result->fetchArray(SQLITE3_ASSOC)) {
+    $videos[] = $row;
+}
+?>
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>ATF Library</title>
+    <style>
+        :root {
+            --bg: #0f0f0f;
+            --card: #1c1c1c;
+            --muted: #aaaaaa;
+            --accent: #ff1a1a;
+            --text: #ffffff;
+            --outline: #2b2b2b;
+        }
+
+        * {
+            box-sizing: border-box;
+            font-family: "Inter", "Segoe UI", sans-serif;
+        }
+
+        body {
+            margin: 0;
+            background: var(--bg);
+            color: var(--text);
+        }
+
+        header {
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            padding: 18px 32px;
+            border-bottom: 1px solid var(--outline);
+        }
+
+        .pill {
+            padding: 8px 16px;
+            border-radius: 999px;
+            background: #232323;
+            border: 1px solid var(--outline);
+            color: var(--text);
+            text-decoration: none;
+            font-size: 14px;
+        }
+
+        main {
+            max-width: 1100px;
+            margin: 32px auto;
+            padding: 0 24px 48px;
+        }
+
+        .filters {
+            display: grid;
+            gap: 12px;
+            grid-template-columns: 2fr 1fr auto;
+            margin-bottom: 20px;
+        }
+
+        input, select {
+            padding: 10px 12px;
+            border-radius: 10px;
+            border: 1px solid var(--outline);
+            background: #141414;
+            color: var(--text);
+        }
+
+        button {
+            padding: 10px 16px;
+            border-radius: 10px;
+            border: none;
+            background: var(--accent);
+            color: #fff;
+            font-weight: 600;
+            cursor: pointer;
+        }
+
+        .grid {
+            display: grid;
+            gap: 16px;
+            grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+        }
+
+        .card {
+            background: var(--card);
+            border-radius: 16px;
+            padding: 16px;
+            border: 1px solid var(--outline);
+        }
+
+        .muted {
+            color: var(--muted);
+            font-size: 13px;
+        }
+    </style>
+</head>
+<body>
+<header>
+    <strong>ATF Library</strong>
+    <div>
+        <a class="pill" href="index.php">Home</a>
+        <a class="pill" href="upload.php">Upload</a>
+        <a class="pill" href="dashboard.php">Dashboard</a>
+        <a class="pill" href="settings.php">Settings</a>
+    </div>
+</header>
+<main>
+    <p class="muted">Showing videos for <?php echo htmlspecialchars($user['username']); ?></p>
+    <form class="filters" method="get">
+        <input type="text" name="search" placeholder="Search by title or description" value="<?php echo htmlspecialchars($search); ?>">
+        <select name="category">
+            <?php foreach ($categories as $option): ?>
+                <option value="<?php echo htmlspecialchars($option); ?>" <?php echo $category === $option ? 'selected' : ''; ?>><?php echo $option === '' ? 'All categories' : htmlspecialchars($option); ?></option>
+            <?php endforeach; ?>
+        </select>
+        <button type="submit">Filter</button>
+    </form>
+
+    <div class="grid">
+        <?php if (count($videos) === 0): ?>
+            <div class="card">
+                <h3>No videos found</h3>
+                <p class="muted">Try a different search or upload something new.</p>
+            </div>
+        <?php else: ?>
+            <?php foreach ($videos as $video): ?>
+                <div class="card">
+                    <h3><?php echo htmlspecialchars($video['title']); ?></h3>
+                    <p class="muted"><?php echo htmlspecialchars($video['category']); ?> · <?php echo number_format((int) $video['views']); ?> views</p>
+                    <p><?php echo htmlspecialchars($video['description']); ?></p>
+                    <p class="muted">Published <?php echo htmlspecialchars(date('M j, Y', strtotime($video['created_at']))); ?></p>
+                </div>
+            <?php endforeach; ?>
+        <?php endif; ?>
+    </div>
+</main>
+</body>
+</html>

--- a/login.php
+++ b/login.php
@@ -1,0 +1,127 @@
+<?php
+session_start();
+require_once __DIR__ . '/db.php';
+
+$db = get_db();
+$user = null;
+
+if (isset($_SESSION['user_id'])) {
+    $stmt = $db->prepare('SELECT id, username FROM users WHERE id = :id');
+    $stmt->bindValue(':id', $_SESSION['user_id'], SQLITE3_INTEGER);
+    $result = $stmt->execute();
+    $user = $result->fetchArray(SQLITE3_ASSOC) ?: null;
+}
+
+if ($user) {
+    header('Location: index.php');
+    exit;
+}
+?>
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>ATF Login</title>
+    <style>
+        :root {
+            --bg: #0f0f0f;
+            --card: #1c1c1c;
+            --muted: #aaaaaa;
+            --accent: #ff1a1a;
+            --text: #ffffff;
+            --outline: #2b2b2b;
+        }
+
+        * {
+            box-sizing: border-box;
+            font-family: "Inter", "Segoe UI", sans-serif;
+        }
+
+        body {
+            margin: 0;
+            background: var(--bg);
+            color: var(--text);
+            min-height: 100vh;
+            display: grid;
+            place-items: center;
+            padding: 24px;
+        }
+
+        .card {
+            width: min(420px, 100%);
+            background: var(--card);
+            border-radius: 18px;
+            border: 1px solid var(--outline);
+            padding: 28px;
+            display: grid;
+            gap: 16px;
+        }
+
+        label {
+            font-size: 13px;
+            color: var(--muted);
+        }
+
+        input {
+            width: 100%;
+            padding: 10px 12px;
+            border-radius: 10px;
+            border: 1px solid var(--outline);
+            background: #141414;
+            color: var(--text);
+        }
+
+        button {
+            padding: 10px 14px;
+            border-radius: 10px;
+            border: none;
+            background: var(--accent);
+            color: #fff;
+            font-weight: 600;
+            cursor: pointer;
+        }
+
+        .pill {
+            padding: 8px 16px;
+            border-radius: 999px;
+            background: #232323;
+            border: 1px solid var(--outline);
+            color: var(--text);
+            text-decoration: none;
+            font-size: 14px;
+        }
+
+        .error {
+            color: #fca5a5;
+            font-size: 13px;
+        }
+    </style>
+</head>
+<body>
+    <div class="card">
+        <div>
+            <strong>ATF Login</strong>
+            <p class="pill">Welcome back to ATF</p>
+        </div>
+        <?php if (isset($_GET['success'])): ?>
+            <div class="pill">Account created! Log in below.</div>
+        <?php elseif (isset($_GET['error'])): ?>
+            <div class="error"><?php echo htmlspecialchars($_GET['error']); ?></div>
+        <?php endif; ?>
+        <form method="post" action="auth.php">
+            <input type="hidden" name="action" value="login">
+            <label>Username</label>
+            <input type="text" name="username" required>
+            <label>Password</label>
+            <input type="password" name="password" required>
+            <button type="submit">Log in</button>
+        </form>
+        <div>
+            <span class="pill">New here?</span>
+            <a class="pill" href="signup.php">Create an account</a>
+            <a class="pill" href="index.php">Back to home</a>
+        </div>
+    </div>
+</body>
+</html>

--- a/login.php
+++ b/login.php
@@ -48,14 +48,36 @@ if ($user) {
             padding: 24px;
         }
 
+        .layout {
+            display: grid;
+            grid-template-columns: 1.1fr 0.9fr;
+            gap: 24px;
+            width: min(960px, 100%);
+        }
+
         .card {
-            width: min(420px, 100%);
             background: var(--card);
             border-radius: 18px;
             border: 1px solid var(--outline);
             padding: 28px;
             display: grid;
             gap: 16px;
+        }
+
+        .side-panel {
+            background: linear-gradient(135deg, rgba(255, 26, 26, 0.18), rgba(255, 255, 255, 0.06));
+            border-radius: 18px;
+            border: 1px solid rgba(255, 255, 255, 0.08);
+            padding: 28px;
+            display: grid;
+            gap: 12px;
+        }
+
+        .side-panel ul {
+            margin: 0;
+            padding-left: 18px;
+            color: var(--muted);
+            font-size: 14px;
         }
 
         label {
@@ -96,31 +118,49 @@ if ($user) {
             color: #fca5a5;
             font-size: 13px;
         }
+
+        @media (max-width: 900px) {
+            .layout {
+                grid-template-columns: 1fr;
+            }
+        }
     </style>
 </head>
 <body>
-    <div class="card">
-        <div>
-            <strong>ATF Login</strong>
-            <p class="pill">Welcome back to ATF</p>
+    <div class="layout">
+        <div class="card">
+            <div>
+                <strong>ATF Login</strong>
+                <p class="pill">Welcome back to ATF</p>
+            </div>
+            <?php if (isset($_GET['success'])): ?>
+                <div class="pill">Account created! Log in below.</div>
+            <?php elseif (isset($_GET['error'])): ?>
+                <div class="error"><?php echo htmlspecialchars($_GET['error']); ?></div>
+            <?php endif; ?>
+            <form method="post" action="auth.php">
+                <input type="hidden" name="action" value="login">
+                <label>Username</label>
+                <input type="text" name="username" required>
+                <label>Password</label>
+                <input type="password" name="password" required>
+                <button type="submit">Log in</button>
+            </form>
+            <div>
+                <span class="pill">New here?</span>
+                <a class="pill" href="signup.php">Create an account</a>
+                <a class="pill" href="index.php">Back to home</a>
+            </div>
         </div>
-        <?php if (isset($_GET['success'])): ?>
-            <div class="pill">Account created! Log in below.</div>
-        <?php elseif (isset($_GET['error'])): ?>
-            <div class="error"><?php echo htmlspecialchars($_GET['error']); ?></div>
-        <?php endif; ?>
-        <form method="post" action="auth.php">
-            <input type="hidden" name="action" value="login">
-            <label>Username</label>
-            <input type="text" name="username" required>
-            <label>Password</label>
-            <input type="password" name="password" required>
-            <button type="submit">Log in</button>
-        </form>
-        <div>
-            <span class="pill">New here?</span>
-            <a class="pill" href="signup.php">Create an account</a>
-            <a class="pill" href="index.php">Back to home</a>
+        <div class="side-panel">
+            <h3>Why creators love ATF</h3>
+            <ul>
+                <li>Centralized creator dashboard</li>
+                <li>Upload studio with guided workflow</li>
+                <li>Secure link-based login on any device</li>
+                <li>Real-time library insights</li>
+            </ul>
+            <p class="muted">Log in to keep your audience growing and your library organized.</p>
         </div>
     </div>
 </body>

--- a/logout.php
+++ b/logout.php
@@ -1,0 +1,5 @@
+<?php
+session_start();
+session_destroy();
+header('Location: index.php');
+exit;

--- a/logout.php
+++ b/logout.php
@@ -1,5 +1,9 @@
 <?php
 session_start();
 session_destroy();
-header('Location: index.php');
+$next = $_GET['next'] ?? 'login.php';
+if (str_contains($next, '://') || str_starts_with($next, '//')) {
+    $next = 'login.php';
+}
+header('Location: ' . $next);
 exit;

--- a/qr_login.php
+++ b/qr_login.php
@@ -1,0 +1,24 @@
+<?php
+session_start();
+require_once __DIR__ . '/db.php';
+
+$token = $_GET['token'] ?? '';
+if ($token === '') {
+    header('Location: index.php?error=Missing+token');
+    exit;
+}
+
+$db = get_db();
+$stmt = $db->prepare('SELECT id FROM users WHERE qr_token = :token');
+$stmt->bindValue(':token', $token, SQLITE3_TEXT);
+$result = $stmt->execute();
+$user = $result->fetchArray(SQLITE3_ASSOC);
+
+if (!$user) {
+    header('Location: index.php?error=Invalid+QR+token');
+    exit;
+}
+
+$_SESSION['user_id'] = (int) $user['id'];
+header('Location: index.php');
+exit;

--- a/qr_login.php
+++ b/qr_login.php
@@ -8,6 +8,15 @@ if ($token === '') {
     exit;
 }
 
+function safe_redirect_target(string $target): string
+{
+    if ($target === '' || str_contains($target, '://') || str_starts_with($target, '//')) {
+        return 'index.php';
+    }
+
+    return $target;
+}
+
 $db = get_db();
 $stmt = $db->prepare('SELECT id FROM users WHERE qr_token = :token');
 $stmt->bindValue(':token', $token, SQLITE3_TEXT);
@@ -20,5 +29,6 @@ if (!$user) {
 }
 
 $_SESSION['user_id'] = (int) $user['id'];
-header('Location: index.php');
+$next = safe_redirect_target($_GET['next'] ?? 'index.php');
+header('Location: ' . $next);
 exit;

--- a/settings.php
+++ b/settings.php
@@ -20,8 +20,43 @@ if (!$user) {
 $messages = [];
 $errors = [];
 
+$profileStmt = $db->prepare('SELECT display_name, bio, location, theme FROM profiles WHERE user_id = :user_id');
+$profileStmt->bindValue(':user_id', $user['id'], SQLITE3_INTEGER);
+$profileResult = $profileStmt->execute();
+$profile = $profileResult->fetchArray(SQLITE3_ASSOC) ?: [
+    'display_name' => $user['username'],
+    'bio' => '',
+    'location' => '',
+    'theme' => 'midnight'
+];
+
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     $action = $_POST['action'] ?? '';
+
+    if ($action === 'update_profile') {
+        $displayName = trim($_POST['display_name'] ?? '');
+        $bio = trim($_POST['bio'] ?? '');
+        $location = trim($_POST['location'] ?? '');
+        $theme = trim($_POST['theme'] ?? 'midnight');
+
+        if ($displayName === '') {
+            $errors[] = 'Display name is required.';
+        } else {
+            $updateProfile = $db->prepare('INSERT INTO profiles (user_id, display_name, bio, location, theme) VALUES (:user_id, :display_name, :bio, :location, :theme)
+                ON CONFLICT(user_id) DO UPDATE SET display_name = excluded.display_name, bio = excluded.bio, location = excluded.location, theme = excluded.theme');
+            $updateProfile->bindValue(':user_id', $user['id'], SQLITE3_INTEGER);
+            $updateProfile->bindValue(':display_name', $displayName, SQLITE3_TEXT);
+            $updateProfile->bindValue(':bio', $bio, SQLITE3_TEXT);
+            $updateProfile->bindValue(':location', $location, SQLITE3_TEXT);
+            $updateProfile->bindValue(':theme', $theme, SQLITE3_TEXT);
+            $updateProfile->execute();
+            $messages[] = 'Profile updated.';
+            $profile['display_name'] = $displayName;
+            $profile['bio'] = $bio;
+            $profile['location'] = $location;
+            $profile['theme'] = $theme;
+        }
+    }
 
     if ($action === 'regenerate_qr') {
         $newToken = bin2hex(random_bytes(16));
@@ -121,6 +156,12 @@ $qrLoginUrl = sprintf('%s://%s%s/qr_login.php?token=%s',
             grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
         }
 
+        .form-grid {
+            display: grid;
+            gap: 12px;
+            grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+        }
+
         .card {
             background: var(--card);
             border-radius: 16px;
@@ -142,6 +183,20 @@ $qrLoginUrl = sprintf('%s://%s%s/qr_login.php?token=%s',
             border: 1px solid var(--outline);
             background: #141414;
             color: var(--text);
+        }
+
+        textarea, select {
+            width: 100%;
+            padding: 10px 12px;
+            border-radius: 10px;
+            border: 1px solid var(--outline);
+            background: #141414;
+            color: var(--text);
+        }
+
+        textarea {
+            min-height: 120px;
+            resize: vertical;
         }
 
         button {
@@ -193,6 +248,31 @@ $qrLoginUrl = sprintf('%s://%s%s/qr_login.php?token=%s',
     </div>
 
     <div class="grid" style="margin-top: 16px;">
+        <div class="card">
+            <h3>Creator profile</h3>
+            <form method="post">
+                <input type="hidden" name="action" value="update_profile">
+                <div class="form-grid">
+                    <div>
+                        <label>Display name</label>
+                        <input type="text" name="display_name" value="<?php echo htmlspecialchars($profile['display_name']); ?>" required>
+                    </div>
+                    <div>
+                        <label>Location</label>
+                        <input type="text" name="location" value="<?php echo htmlspecialchars($profile['location']); ?>">
+                    </div>
+                </div>
+                <label>Bio</label>
+                <textarea name="bio"><?php echo htmlspecialchars($profile['bio']); ?></textarea>
+                <label>Theme</label>
+                <select name="theme">
+                    <?php foreach (['midnight', 'neon', 'aurora', 'classic'] as $theme): ?>
+                        <option value="<?php echo $theme; ?>" <?php echo $profile['theme'] === $theme ? 'selected' : ''; ?>><?php echo ucfirst($theme); ?></option>
+                    <?php endforeach; ?>
+                </select>
+                <button type="submit">Save profile</button>
+            </form>
+        </div>
         <div class="card">
             <h3>Login link</h3>
             <p class="muted">Use this secure link to sign in on another device.</p>

--- a/settings.php
+++ b/settings.php
@@ -1,0 +1,219 @@
+<?php
+session_start();
+require_once __DIR__ . '/db.php';
+
+$db = get_db();
+$user = null;
+
+if (isset($_SESSION['user_id'])) {
+    $stmt = $db->prepare('SELECT id, username, qr_token, created_at FROM users WHERE id = :id');
+    $stmt->bindValue(':id', $_SESSION['user_id'], SQLITE3_INTEGER);
+    $result = $stmt->execute();
+    $user = $result->fetchArray(SQLITE3_ASSOC) ?: null;
+}
+
+if (!$user) {
+    header('Location: index.php?error=Please+log+in+to+view+settings');
+    exit;
+}
+
+$messages = [];
+$errors = [];
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $action = $_POST['action'] ?? '';
+
+    if ($action === 'regenerate_qr') {
+        $newToken = bin2hex(random_bytes(16));
+        $stmt = $db->prepare('UPDATE users SET qr_token = :token WHERE id = :id');
+        $stmt->bindValue(':token', $newToken, SQLITE3_TEXT);
+        $stmt->bindValue(':id', $user['id'], SQLITE3_INTEGER);
+        $stmt->execute();
+        $messages[] = 'QR login token regenerated.';
+        $user['qr_token'] = $newToken;
+    }
+
+    if ($action === 'change_password') {
+        $current = $_POST['current_password'] ?? '';
+        $new = $_POST['new_password'] ?? '';
+
+        $check = $db->prepare('SELECT password_hash FROM users WHERE id = :id');
+        $check->bindValue(':id', $user['id'], SQLITE3_INTEGER);
+        $result = $check->execute();
+        $row = $result->fetchArray(SQLITE3_ASSOC);
+
+        if (!$row || !password_verify($current, $row['password_hash'])) {
+            $errors[] = 'Current password is incorrect.';
+        } elseif (strlen($new) < 6) {
+            $errors[] = 'New password must be at least 6 characters.';
+        } else {
+            $hash = password_hash($new, PASSWORD_DEFAULT);
+            $update = $db->prepare('UPDATE users SET password_hash = :hash WHERE id = :id');
+            $update->bindValue(':hash', $hash, SQLITE3_TEXT);
+            $update->bindValue(':id', $user['id'], SQLITE3_INTEGER);
+            $update->execute();
+            $messages[] = 'Password updated successfully.';
+        }
+    }
+}
+
+$qrLoginUrl = sprintf('%s://%s%s/qr_login.php?token=%s',
+    (!empty($_SERVER['HTTPS']) && $_SERVER['HTTPS'] !== 'off') ? 'https' : 'http',
+    $_SERVER['HTTP_HOST'],
+    rtrim(dirname($_SERVER['PHP_SELF']), '/'),
+    urlencode($user['qr_token'])
+);
+?>
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>ATF Account Settings</title>
+    <style>
+        :root {
+            --bg: #0f0f0f;
+            --card: #1c1c1c;
+            --muted: #aaaaaa;
+            --accent: #ff1a1a;
+            --text: #ffffff;
+            --outline: #2b2b2b;
+        }
+
+        * {
+            box-sizing: border-box;
+            font-family: "Inter", "Segoe UI", sans-serif;
+        }
+
+        body {
+            margin: 0;
+            background: var(--bg);
+            color: var(--text);
+        }
+
+        header {
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            padding: 18px 32px;
+            border-bottom: 1px solid var(--outline);
+        }
+
+        .pill {
+            padding: 8px 16px;
+            border-radius: 999px;
+            background: #232323;
+            border: 1px solid var(--outline);
+            color: var(--text);
+            text-decoration: none;
+            font-size: 14px;
+        }
+
+        main {
+            max-width: 1000px;
+            margin: 32px auto;
+            padding: 0 24px 48px;
+        }
+
+        .grid {
+            display: grid;
+            gap: 16px;
+            grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+        }
+
+        .card {
+            background: var(--card);
+            border-radius: 16px;
+            padding: 18px;
+            border: 1px solid var(--outline);
+        }
+
+        label {
+            display: block;
+            font-size: 13px;
+            color: var(--muted);
+            margin-bottom: 8px;
+        }
+
+        input {
+            width: 100%;
+            padding: 10px 12px;
+            border-radius: 10px;
+            border: 1px solid var(--outline);
+            background: #141414;
+            color: var(--text);
+        }
+
+        button {
+            margin-top: 12px;
+            padding: 10px 16px;
+            border-radius: 10px;
+            border: none;
+            background: var(--accent);
+            color: #fff;
+            font-weight: 600;
+            cursor: pointer;
+        }
+
+        .muted {
+            color: var(--muted);
+            font-size: 13px;
+        }
+
+        .success {
+            color: #6ee7b7;
+        }
+
+        .error {
+            color: #fca5a5;
+        }
+    </style>
+</head>
+<body>
+<header>
+    <strong>ATF Account Settings</strong>
+    <div>
+        <a class="pill" href="index.php">Home</a>
+        <a class="pill" href="upload.php">Upload</a>
+        <a class="pill" href="library.php">Library</a>
+        <a class="pill" href="dashboard.php">Dashboard</a>
+    </div>
+</header>
+<main>
+    <div class="card">
+        <h2>Profile</h2>
+        <p><strong><?php echo htmlspecialchars($user['username']); ?></strong></p>
+        <p class="muted">Member since <?php echo htmlspecialchars(date('M j, Y', strtotime($user['created_at']))); ?></p>
+        <?php foreach ($messages as $message): ?>
+            <p class="success"><?php echo htmlspecialchars($message); ?></p>
+        <?php endforeach; ?>
+        <?php foreach ($errors as $error): ?>
+            <p class="error"><?php echo htmlspecialchars($error); ?></p>
+        <?php endforeach; ?>
+    </div>
+
+    <div class="grid" style="margin-top: 16px;">
+        <div class="card">
+            <h3>QR Login</h3>
+            <p class="muted">Scan to sign in on another device.</p>
+            <img src="https://chart.googleapis.com/chart?chs=200x200&cht=qr&chl=<?php echo urlencode($qrLoginUrl); ?>" alt="QR code" style="width: 180px; height: 180px; border-radius: 12px; background: #fff; border: 1px solid var(--outline);">
+            <form method="post">
+                <input type="hidden" name="action" value="regenerate_qr">
+                <button type="submit">Regenerate QR Token</button>
+            </form>
+        </div>
+        <div class="card">
+            <h3>Change password</h3>
+            <form method="post">
+                <input type="hidden" name="action" value="change_password">
+                <label>Current password</label>
+                <input type="password" name="current_password" required>
+                <label>New password</label>
+                <input type="password" name="new_password" required>
+                <button type="submit">Update password</button>
+            </form>
+        </div>
+    </div>
+</main>
+</body>
+</html>

--- a/settings.php
+++ b/settings.php
@@ -194,12 +194,12 @@ $qrLoginUrl = sprintf('%s://%s%s/qr_login.php?token=%s',
 
     <div class="grid" style="margin-top: 16px;">
         <div class="card">
-            <h3>QR Login</h3>
-            <p class="muted">Scan to sign in on another device.</p>
-            <img src="https://chart.googleapis.com/chart?chs=200x200&cht=qr&chl=<?php echo urlencode($qrLoginUrl); ?>" alt="QR code" style="width: 180px; height: 180px; border-radius: 12px; background: #fff; border: 1px solid var(--outline);">
+            <h3>Login link</h3>
+            <p class="muted">Use this secure link to sign in on another device.</p>
+            <p class="muted"><?php echo htmlspecialchars($qrLoginUrl); ?></p>
             <form method="post">
                 <input type="hidden" name="action" value="regenerate_qr">
-                <button type="submit">Regenerate QR Token</button>
+                <button type="submit">Regenerate login token</button>
             </form>
         </div>
         <div class="card">

--- a/signup.php
+++ b/signup.php
@@ -48,14 +48,36 @@ if ($user) {
             padding: 24px;
         }
 
+        .layout {
+            display: grid;
+            grid-template-columns: 1.1fr 0.9fr;
+            gap: 24px;
+            width: min(960px, 100%);
+        }
+
         .card {
-            width: min(440px, 100%);
             background: var(--card);
             border-radius: 18px;
             border: 1px solid var(--outline);
             padding: 28px;
             display: grid;
             gap: 16px;
+        }
+
+        .side-panel {
+            background: linear-gradient(135deg, rgba(255, 26, 26, 0.18), rgba(255, 255, 255, 0.06));
+            border-radius: 18px;
+            border: 1px solid rgba(255, 255, 255, 0.08);
+            padding: 28px;
+            display: grid;
+            gap: 12px;
+        }
+
+        .side-panel ul {
+            margin: 0;
+            padding-left: 18px;
+            color: var(--muted);
+            font-size: 14px;
         }
 
         label {
@@ -96,29 +118,47 @@ if ($user) {
             color: #fca5a5;
             font-size: 13px;
         }
+
+        @media (max-width: 900px) {
+            .layout {
+                grid-template-columns: 1fr;
+            }
+        }
     </style>
 </head>
 <body>
-    <div class="card">
-        <div>
-            <strong>Create your ATF account</strong>
-            <p class="pill">Join the creator community</p>
+    <div class="layout">
+        <div class="card">
+            <div>
+                <strong>Create your ATF account</strong>
+                <p class="pill">Join the creator community</p>
+            </div>
+            <?php if (isset($_GET['error'])): ?>
+                <div class="error"><?php echo htmlspecialchars($_GET['error']); ?></div>
+            <?php endif; ?>
+            <form method="post" action="auth.php">
+                <input type="hidden" name="action" value="signup">
+                <label>Username</label>
+                <input type="text" name="username" required>
+                <label>Password</label>
+                <input type="password" name="password" required>
+                <button type="submit">Sign up</button>
+            </form>
+            <div>
+                <span class="pill">Already have an account?</span>
+                <a class="pill" href="login.php">Log in</a>
+                <a class="pill" href="index.php">Back to home</a>
+            </div>
         </div>
-        <?php if (isset($_GET['error'])): ?>
-            <div class="error"><?php echo htmlspecialchars($_GET['error']); ?></div>
-        <?php endif; ?>
-        <form method="post" action="auth.php">
-            <input type="hidden" name="action" value="signup">
-            <label>Username</label>
-            <input type="text" name="username" required>
-            <label>Password</label>
-            <input type="password" name="password" required>
-            <button type="submit">Sign up</button>
-        </form>
-        <div>
-            <span class="pill">Already have an account?</span>
-            <a class="pill" href="login.php">Log in</a>
-            <a class="pill" href="index.php">Back to home</a>
+        <div class="side-panel">
+            <h3>Start strong with ATF</h3>
+            <ul>
+                <li>Personalized creator workspace</li>
+                <li>Organized library with filters</li>
+                <li>Secure login link for any device</li>
+                <li>Actionable dashboard insights</li>
+            </ul>
+            <p class="muted">Sign up to unlock uploads, analytics, and pro creator tools.</p>
         </div>
     </div>
 </body>

--- a/signup.php
+++ b/signup.php
@@ -1,0 +1,125 @@
+<?php
+session_start();
+require_once __DIR__ . '/db.php';
+
+$db = get_db();
+$user = null;
+
+if (isset($_SESSION['user_id'])) {
+    $stmt = $db->prepare('SELECT id, username FROM users WHERE id = :id');
+    $stmt->bindValue(':id', $_SESSION['user_id'], SQLITE3_INTEGER);
+    $result = $stmt->execute();
+    $user = $result->fetchArray(SQLITE3_ASSOC) ?: null;
+}
+
+if ($user) {
+    header('Location: index.php');
+    exit;
+}
+?>
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>ATF Sign Up</title>
+    <style>
+        :root {
+            --bg: #0f0f0f;
+            --card: #1c1c1c;
+            --muted: #aaaaaa;
+            --accent: #ff1a1a;
+            --text: #ffffff;
+            --outline: #2b2b2b;
+        }
+
+        * {
+            box-sizing: border-box;
+            font-family: "Inter", "Segoe UI", sans-serif;
+        }
+
+        body {
+            margin: 0;
+            background: var(--bg);
+            color: var(--text);
+            min-height: 100vh;
+            display: grid;
+            place-items: center;
+            padding: 24px;
+        }
+
+        .card {
+            width: min(440px, 100%);
+            background: var(--card);
+            border-radius: 18px;
+            border: 1px solid var(--outline);
+            padding: 28px;
+            display: grid;
+            gap: 16px;
+        }
+
+        label {
+            font-size: 13px;
+            color: var(--muted);
+        }
+
+        input {
+            width: 100%;
+            padding: 10px 12px;
+            border-radius: 10px;
+            border: 1px solid var(--outline);
+            background: #141414;
+            color: var(--text);
+        }
+
+        button {
+            padding: 10px 14px;
+            border-radius: 10px;
+            border: none;
+            background: var(--accent);
+            color: #fff;
+            font-weight: 600;
+            cursor: pointer;
+        }
+
+        .pill {
+            padding: 8px 16px;
+            border-radius: 999px;
+            background: #232323;
+            border: 1px solid var(--outline);
+            color: var(--text);
+            text-decoration: none;
+            font-size: 14px;
+        }
+
+        .error {
+            color: #fca5a5;
+            font-size: 13px;
+        }
+    </style>
+</head>
+<body>
+    <div class="card">
+        <div>
+            <strong>Create your ATF account</strong>
+            <p class="pill">Join the creator community</p>
+        </div>
+        <?php if (isset($_GET['error'])): ?>
+            <div class="error"><?php echo htmlspecialchars($_GET['error']); ?></div>
+        <?php endif; ?>
+        <form method="post" action="auth.php">
+            <input type="hidden" name="action" value="signup">
+            <label>Username</label>
+            <input type="text" name="username" required>
+            <label>Password</label>
+            <input type="password" name="password" required>
+            <button type="submit">Sign up</button>
+        </form>
+        <div>
+            <span class="pill">Already have an account?</span>
+            <a class="pill" href="login.php">Log in</a>
+            <a class="pill" href="index.php">Back to home</a>
+        </div>
+    </div>
+</body>
+</html>

--- a/upload.php
+++ b/upload.php
@@ -17,6 +17,11 @@ if (!$user) {
     exit;
 }
 
+$statsStmt = $db->prepare('SELECT COUNT(*) as total, COALESCE(SUM(views), 0) as views FROM videos WHERE user_id = :user_id');
+$statsStmt->bindValue(':user_id', $user['id'], SQLITE3_INTEGER);
+$statsResult = $statsStmt->execute();
+$stats = $statsResult->fetchArray(SQLITE3_ASSOC) ?: ['total' => 0, 'views' => 0];
+
 $errors = [];
 $success = false;
 $title = '';
@@ -47,6 +52,13 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         $stmt->bindValue(':description', $description, SQLITE3_TEXT);
         $stmt->bindValue(':category', $category, SQLITE3_TEXT);
         $stmt->execute();
+
+        $notifStmt = $db->prepare('INSERT INTO notifications (user_id, title, body) VALUES (:user_id, :title, :body)');
+        $notifStmt->bindValue(':user_id', $user['id'], SQLITE3_INTEGER);
+        $notifStmt->bindValue(':title', 'Upload ready for review', SQLITE3_TEXT);
+        $notifStmt->bindValue(':body', 'Your video "' . $title . '" is now in your library.', SQLITE3_TEXT);
+        $notifStmt->execute();
+
         $success = true;
         $title = '';
         $description = '';
@@ -113,6 +125,12 @@ $categories = ['Tech', 'Music', 'Education', 'Gaming', 'Lifestyle', 'Sports'];
             padding: 24px;
         }
 
+        .layout {
+            display: grid;
+            grid-template-columns: 2fr 1fr;
+            gap: 20px;
+        }
+
         form {
             display: grid;
             gap: 16px;
@@ -162,6 +180,28 @@ $categories = ['Tech', 'Music', 'Education', 'Gaming', 'Lifestyle', 'Sports'];
             gap: 16px;
             grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
         }
+
+        .checklist {
+            display: grid;
+            gap: 10px;
+            color: var(--muted);
+            font-size: 13px;
+        }
+
+        .badge {
+            display: inline-block;
+            padding: 4px 10px;
+            border-radius: 999px;
+            background: rgba(255, 26, 26, 0.16);
+            color: #ffb4b4;
+            font-size: 12px;
+        }
+
+        @media (max-width: 960px) {
+            .layout {
+                grid-template-columns: 1fr;
+            }
+        }
     </style>
 </head>
 <body>
@@ -175,39 +215,54 @@ $categories = ['Tech', 'Music', 'Education', 'Gaming', 'Lifestyle', 'Sports'];
     </div>
 </header>
 <main>
-    <div class="card">
-        <h2>Upload a new video</h2>
-        <p class="pill">Signed in as <?php echo htmlspecialchars($user['username']); ?></p>
+    <div class="layout">
+        <div class="card">
+            <h2>Upload a new video</h2>
+            <p class="pill">Signed in as <?php echo htmlspecialchars($user['username']); ?></p>
 
-        <?php if ($success): ?>
-            <p class="success">Your video draft has been added to ATF!</p>
-        <?php endif; ?>
+            <?php if ($success): ?>
+                <p class="success">Your video draft has been added to ATF!</p>
+            <?php endif; ?>
 
-        <?php foreach ($errors as $error): ?>
-            <p class="error"><?php echo htmlspecialchars($error); ?></p>
-        <?php endforeach; ?>
+            <?php foreach ($errors as $error): ?>
+                <p class="error"><?php echo htmlspecialchars($error); ?></p>
+            <?php endforeach; ?>
 
-        <form method="post">
-            <div class="grid">
-                <div>
-                    <label>Video title</label>
-                    <input type="text" name="title" value="<?php echo htmlspecialchars($title); ?>" required>
+            <form method="post">
+                <div class="grid">
+                    <div>
+                        <label>Video title</label>
+                        <input type="text" name="title" value="<?php echo htmlspecialchars($title); ?>" required>
+                    </div>
+                    <div>
+                        <label>Category</label>
+                        <select name="category">
+                            <?php foreach ($categories as $option): ?>
+                                <option value="<?php echo htmlspecialchars($option); ?>" <?php echo $category === $option ? 'selected' : ''; ?>><?php echo htmlspecialchars($option); ?></option>
+                            <?php endforeach; ?>
+                        </select>
+                    </div>
                 </div>
                 <div>
-                    <label>Category</label>
-                    <select name="category">
-                        <?php foreach ($categories as $option): ?>
-                            <option value="<?php echo htmlspecialchars($option); ?>" <?php echo $category === $option ? 'selected' : ''; ?>><?php echo htmlspecialchars($option); ?></option>
-                        <?php endforeach; ?>
-                    </select>
+                    <label>Description</label>
+                    <textarea name="description" required><?php echo htmlspecialchars($description); ?></textarea>
                 </div>
+                <button type="submit">Publish to ATF</button>
+            </form>
+        </div>
+        <div class="card">
+            <h3>Creator snapshot</h3>
+            <p class="muted">Your channel momentum this month.</p>
+            <p><span class="badge"><?php echo number_format((int) $stats['total']); ?> uploads</span></p>
+            <p><span class="badge"><?php echo number_format((int) $stats['views']); ?> total views</span></p>
+            <h4>Upload checklist</h4>
+            <div class="checklist">
+                <span>✔ Write a clear title</span>
+                <span>✔ Choose the best category</span>
+                <span>✔ Add a helpful description</span>
+                <span>✔ Share with your community</span>
             </div>
-            <div>
-                <label>Description</label>
-                <textarea name="description" required><?php echo htmlspecialchars($description); ?></textarea>
-            </div>
-            <button type="submit">Publish to ATF</button>
-        </form>
+        </div>
     </div>
 </main>
 </body>

--- a/upload.php
+++ b/upload.php
@@ -1,0 +1,214 @@
+<?php
+session_start();
+require_once __DIR__ . '/db.php';
+
+$db = get_db();
+$user = null;
+
+if (isset($_SESSION['user_id'])) {
+    $stmt = $db->prepare('SELECT id, username FROM users WHERE id = :id');
+    $stmt->bindValue(':id', $_SESSION['user_id'], SQLITE3_INTEGER);
+    $result = $stmt->execute();
+    $user = $result->fetchArray(SQLITE3_ASSOC) ?: null;
+}
+
+if (!$user) {
+    header('Location: index.php?error=Please+log+in+to+upload');
+    exit;
+}
+
+$errors = [];
+$success = false;
+$title = '';
+$description = '';
+$category = 'Tech';
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $title = trim($_POST['title'] ?? '');
+    $description = trim($_POST['description'] ?? '');
+    $category = trim($_POST['category'] ?? 'Tech');
+
+    if ($title === '') {
+        $errors[] = 'Title is required.';
+    }
+
+    if ($description === '') {
+        $errors[] = 'Description is required.';
+    }
+
+    if ($category === '') {
+        $errors[] = 'Category is required.';
+    }
+
+    if (count($errors) === 0) {
+        $stmt = $db->prepare('INSERT INTO videos (user_id, title, description, category) VALUES (:user_id, :title, :description, :category)');
+        $stmt->bindValue(':user_id', $user['id'], SQLITE3_INTEGER);
+        $stmt->bindValue(':title', $title, SQLITE3_TEXT);
+        $stmt->bindValue(':description', $description, SQLITE3_TEXT);
+        $stmt->bindValue(':category', $category, SQLITE3_TEXT);
+        $stmt->execute();
+        $success = true;
+        $title = '';
+        $description = '';
+    }
+}
+
+$categories = ['Tech', 'Music', 'Education', 'Gaming', 'Lifestyle', 'Sports'];
+?>
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>ATF Upload Studio</title>
+    <style>
+        :root {
+            --bg: #0f0f0f;
+            --card: #1c1c1c;
+            --muted: #aaaaaa;
+            --accent: #ff1a1a;
+            --text: #ffffff;
+            --outline: #2b2b2b;
+        }
+
+        * {
+            box-sizing: border-box;
+            font-family: "Inter", "Segoe UI", sans-serif;
+        }
+
+        body {
+            margin: 0;
+            background: var(--bg);
+            color: var(--text);
+        }
+
+        header {
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            padding: 18px 32px;
+            border-bottom: 1px solid var(--outline);
+        }
+
+        .pill {
+            padding: 8px 16px;
+            border-radius: 999px;
+            background: #232323;
+            border: 1px solid var(--outline);
+            color: var(--text);
+            text-decoration: none;
+            font-size: 14px;
+        }
+
+        main {
+            max-width: 900px;
+            margin: 32px auto;
+            padding: 0 24px 48px;
+        }
+
+        .card {
+            background: var(--card);
+            border-radius: 18px;
+            border: 1px solid var(--outline);
+            padding: 24px;
+        }
+
+        form {
+            display: grid;
+            gap: 16px;
+        }
+
+        label {
+            font-size: 13px;
+            color: var(--muted);
+        }
+
+        input, textarea, select {
+            width: 100%;
+            padding: 10px 12px;
+            border-radius: 10px;
+            border: 1px solid var(--outline);
+            background: #141414;
+            color: var(--text);
+        }
+
+        textarea {
+            min-height: 120px;
+            resize: vertical;
+        }
+
+        button {
+            padding: 10px 16px;
+            border-radius: 10px;
+            border: none;
+            background: var(--accent);
+            color: #fff;
+            font-weight: 600;
+            cursor: pointer;
+        }
+
+        .success {
+            color: #6ee7b7;
+            font-size: 14px;
+        }
+
+        .error {
+            color: #fca5a5;
+            font-size: 14px;
+        }
+
+        .grid {
+            display: grid;
+            gap: 16px;
+            grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+        }
+    </style>
+</head>
+<body>
+<header>
+    <strong>ATF Upload Studio</strong>
+    <div>
+        <a class="pill" href="index.php">Home</a>
+        <a class="pill" href="library.php">Library</a>
+        <a class="pill" href="dashboard.php">Dashboard</a>
+        <a class="pill" href="settings.php">Settings</a>
+    </div>
+</header>
+<main>
+    <div class="card">
+        <h2>Upload a new video</h2>
+        <p class="pill">Signed in as <?php echo htmlspecialchars($user['username']); ?></p>
+
+        <?php if ($success): ?>
+            <p class="success">Your video draft has been added to ATF!</p>
+        <?php endif; ?>
+
+        <?php foreach ($errors as $error): ?>
+            <p class="error"><?php echo htmlspecialchars($error); ?></p>
+        <?php endforeach; ?>
+
+        <form method="post">
+            <div class="grid">
+                <div>
+                    <label>Video title</label>
+                    <input type="text" name="title" value="<?php echo htmlspecialchars($title); ?>" required>
+                </div>
+                <div>
+                    <label>Category</label>
+                    <select name="category">
+                        <?php foreach ($categories as $option): ?>
+                            <option value="<?php echo htmlspecialchars($option); ?>" <?php echo $category === $option ? 'selected' : ''; ?>><?php echo htmlspecialchars($option); ?></option>
+                        <?php endforeach; ?>
+                    </select>
+                </div>
+            </div>
+            <div>
+                <label>Description</label>
+                <textarea name="description" required><?php echo htmlspecialchars($description); ?></textarea>
+            </div>
+            <button type="submit">Publish to ATF</button>
+        </form>
+    </div>
+</main>
+</body>
+</html>


### PR DESCRIPTION
### Motivation
- Remove hard-coded placeholder video data so the UI reflects an empty/real-data feed.
- Show a clear, friendly empty-state when no videos are present to guide users to upload content.

### Description
- Replace the hard-coded `$videos` sample array in `index.php` with an empty array and add an `.empty-state` UI block. 
- Update the template to conditionally render the empty-state when `count($videos) === 0` and include styling for `.empty-state` in the page stylesheet.
- Changes are limited to `index.php` to remove fake data and provide the empty feed UX.

### Testing
- Started the PHP development server with `php -S 0.0.0.0:8000` which started successfully. 
- Ran a Playwright script that loaded `http://127.0.0.1:8000/index.php` and produced a screenshot at `artifacts/atf-home-empty.png` confirming the empty-state renders. 
- No unit tests were added or run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6963024309cc8330a34cc143f9a9ca47)