### PR TITLE
Rebuild VEN as a terminal-first developer toolkit

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,55 @@ List available plugins:
 ./tuxpad plugins
 ```
 
-## Plugin model
+## JavaScript API (No local clone required)
+
+VEN also provides a browser/Node-compatible JavaScript library so developers can
+use file-metric APIs and plugin hooks through CDNs without downloading this
+repository.
+
+### GitHub CDN options
+
+Use one of these endpoints (replace `<owner>`, `<repo>`, and `<tag>`):
+
+```html
+<!-- jsDelivr via GitHub -->
+<script src="https://cdn.jsdelivr.net/gh/<owner>/<repo>@<tag>/js/ven.js"></script>
+
+<!-- GitHub raw CDN style -->
+<script src="https://raw.githubusercontent.com/<owner>/<repo>/<tag>/js/ven.js"></script>
+```
+
+### Browser example
+
+```html
+<script src="https://cdn.jsdelivr.net/gh/<owner>/<repo>@<tag>/js/ven.js"></script>
+<script>
+  const result = VEN.scan('hello\nworld\n', { plugins: 'none' });
+  console.log(result.metrics); // { lines: 2, words: 2, bytes: 12 }
+</script>
+```
+
+### Node.js example
+
+```js
+const VEN = require('./js/ven.js');
+
+VEN.use('uppercaseWords', ({ text }) => text.toUpperCase().split(/\s+/).length);
+const result = VEN.scan('ven makes terminal tools simple', { plugins: 'all' });
+console.log(result);
+```
+
+### JS API reference
+
+- `VEN.countLines(text)`
+- `VEN.countWords(text)`
+- `VEN.countBytes(text)`
+- `VEN.scan(text, { plugins: 'none' | 'all' | string | string[] })`
+- `VEN.use(name, pluginFn)`
+- `VEN.listPlugins()`
+- `VEN.runPlugin(name, payload)`
+
+## Plugin model (C CLI)
 
 Plugins are shared libraries in `plugins/` and must export:
 

--- a/README.md
+++ b/README.md
@@ -1,60 +1,74 @@
 # VEN
 
-VEN is a prototype code editor now implemented purely in C. It demonstrates a
-very small plugin system that loads tools as shared libraries at runtime.
+VEN is a terminal-first, open-source toolkit for developers. It is built in C,
+ships as a single CLI binary (`tuxpad`), and supports runtime plugins so teams
+can extend local infrastructure checks without rebuilding the core.
 
-## Building
+## What it does
 
-Use `make` to build the `tuxpad` binary and example plugin:
+`./tuxpad` helps developers run local file and system checks from the terminal:
+
+- scan files for lines, words, and bytes
+- load Linux-compatible `.so` plugins dynamically
+- keep core tooling minimal while allowing extension via plugins
+
+## Build
 
 ```sh
 make
 ```
 
-Run the program by providing a file name:
+## CLI usage
+
+Quick scan (default mode):
 
 ```sh
 ./tuxpad path/to/file.txt
 ```
 
-The program counts the number of lines in the given file and then demonstrates
-loading plugins from the `plugins/` directory if they exist. Plugins must
-export a `void run(const char *filename)` function. The provided plugins
-include a word counter as well as Linux tools that print system and disk
-information.
+Explicit scan modes:
 
-### Plugins
+```sh
+./tuxpad scan path/to/file.txt          # scan + run all plugins
+./tuxpad scan path/to/file.txt none     # scan only
+./tuxpad scan path/to/file.txt wordcount
+```
 
-Plugins are C shared libraries stored in the `plugins/` directory. Each library
-should define a `run` function accepting the file name to operate on. The
-`tuxpad` executable loads any available plugins after counting lines. Provided
-plugins include:
+List available plugins:
 
-* `wordcount.so` &ndash; counts words in the file
-* `sysinfo.so` &ndash; prints basic CPU and memory information
-* `diskusage.so` &ndash; shows disk usage for the file's filesystem
+```sh
+./tuxpad plugins
+```
 
-### Build & Run
+## Plugin model
 
-`make` also builds the example plugins so running `./tuxpad FILE` will count
-lines and then invoke any plugins found in the `plugins/` directory.
+Plugins are shared libraries in `plugins/` and must export:
 
-## GUI
+```c
+void run(const char *filename)
+```
 
-An optional Tkinter interface is included for experimenting with the plugins.
-Build everything then launch the GUI with:
+During `scan`, VEN discovers all `.so` files in `plugins/` and executes either:
+
+- all plugins (`all` mode, default)
+- no plugins (`none`)
+- one plugin selected by name fragment
+
+Provided reference plugins:
+
+- `wordcount.so`: word metrics for the file
+- `sysinfo.so`: Linux system and memory summary
+- `diskusage.so`: filesystem space info
+
+## Optional GUI
+
+A lightweight Tkinter UI remains available for experimentation:
 
 ```sh
 make gui
 ```
 
-The GUI allows you to open a file and run the available plugins from the
-`Plugins` menu. If no graphical display is available the GUI will exit with a
-message.
-
-## Cleaning
-
-To clean build artifacts run:
+## Clean
 
 ```sh
 make clean

--- a/js/ven.js
+++ b/js/ven.js
@@ -1,0 +1,112 @@
+(function (global, factory) {
+  if (typeof module === 'object' && typeof module.exports === 'object') {
+    module.exports = factory();
+  } else {
+    global.VEN = factory();
+  }
+})(typeof window !== 'undefined' ? window : globalThis, function () {
+  'use strict';
+
+  const plugins = new Map();
+
+  function assertString(value, name) {
+    if (typeof value !== 'string') {
+      throw new TypeError(name + ' must be a string');
+    }
+  }
+
+  function countLines(text) {
+    assertString(text, 'text');
+    if (text.length === 0) {
+      return 0;
+    }
+
+    let lines = 0;
+    for (let i = 0; i < text.length; i += 1) {
+      if (text[i] === '\n') {
+        lines += 1;
+      }
+    }
+
+    return lines;
+  }
+
+  function countWords(text) {
+    assertString(text, 'text');
+    const trimmed = text.trim();
+    if (trimmed.length === 0) {
+      return 0;
+    }
+    return trimmed.split(/\s+/).length;
+  }
+
+  function countBytes(text) {
+    assertString(text, 'text');
+    if (typeof TextEncoder !== 'undefined') {
+      return new TextEncoder().encode(text).length;
+    }
+    if (typeof Buffer !== 'undefined') {
+      return Buffer.byteLength(text, 'utf8');
+    }
+
+    // Conservative fallback for older runtimes.
+    return unescape(encodeURIComponent(text)).length;
+  }
+
+  function use(name, fn) {
+    assertString(name, 'name');
+    if (typeof fn !== 'function') {
+      throw new TypeError('plugin must be a function');
+    }
+    plugins.set(name, fn);
+    return api;
+  }
+
+  function listPlugins() {
+    return Array.from(plugins.keys());
+  }
+
+  function runPlugin(name, payload) {
+    assertString(name, 'name');
+    if (!plugins.has(name)) {
+      throw new Error('Unknown plugin: ' + name);
+    }
+    return plugins.get(name)(payload);
+  }
+
+  function scan(text, options) {
+    const config = options || {};
+    const metrics = {
+      lines: countLines(text),
+      words: countWords(text),
+      bytes: countBytes(text)
+    };
+
+    if (config.plugins === 'none' || config.plugins == null) {
+      return { metrics: metrics, pluginResults: {} };
+    }
+
+    const requested = config.plugins === 'all' ? listPlugins() : config.plugins;
+    const pluginList = Array.isArray(requested) ? requested : [requested];
+    const pluginResults = {};
+
+    for (const name of pluginList) {
+      pluginResults[name] = runPlugin(name, { text: text, metrics: metrics });
+    }
+
+    return { metrics: metrics, pluginResults: pluginResults };
+  }
+
+  const api = {
+    version: '0.1.0',
+    countLines,
+    countWords,
+    countBytes,
+    scan,
+    use,
+    listPlugins,
+    runPlugin
+  };
+
+  return api;
+});

--- a/src/editor_features.c
+++ b/src/editor_features.c
@@ -1,4 +1,5 @@
 #include "editor_features.h"
+#include <ctype.h>
 #include <stdio.h>
 
 int count_lines(const char *filename) {
@@ -6,6 +7,7 @@ int count_lines(const char *filename) {
     if (!f) {
         return -1;
     }
+
     int lines = 0;
     int ch;
     while ((ch = fgetc(f)) != EOF) {
@@ -13,6 +15,50 @@ int count_lines(const char *filename) {
             lines++;
         }
     }
+
     fclose(f);
     return lines;
+}
+
+int count_words(const char *filename) {
+    FILE *f = fopen(filename, "r");
+    if (!f) {
+        return -1;
+    }
+
+    int words = 0;
+    int in_word = 0;
+    int ch;
+    while ((ch = fgetc(f)) != EOF) {
+        if (isspace(ch)) {
+            if (in_word) {
+                words++;
+                in_word = 0;
+            }
+        } else {
+            in_word = 1;
+        }
+    }
+    if (in_word) {
+        words++;
+    }
+
+    fclose(f);
+    return words;
+}
+
+long count_bytes(const char *filename) {
+    FILE *f = fopen(filename, "rb");
+    if (!f) {
+        return -1;
+    }
+
+    if (fseek(f, 0, SEEK_END) != 0) {
+        fclose(f);
+        return -1;
+    }
+
+    long bytes = ftell(f);
+    fclose(f);
+    return bytes;
 }

--- a/src/editor_features.h
+++ b/src/editor_features.h
@@ -6,6 +6,8 @@ extern "C" {
 #endif
 
 int count_lines(const char *filename);
+int count_words(const char *filename);
+long count_bytes(const char *filename);
 
 #ifdef __cplusplus
 }

--- a/src/main.c
+++ b/src/main.c
@@ -1,35 +1,87 @@
 #include <stdio.h>
-#include <stdlib.h>
-#include <unistd.h>
+#include <string.h>
+
 #include "editor_features.h"
 #include "plugin_manager.h"
 
+#define MAX_PLUGINS 64
+
+static void print_usage(const char *prog) {
+    printf("VEN Terminal Developer Toolkit\n");
+    printf("Usage:\n");
+    printf("  %s <file>                           # quick scan + run all plugins\n", prog);
+    printf("  %s scan <file> [plugin|all|none]    # scan file and choose plugin mode\n", prog);
+    printf("  %s plugins                          # list available plugins\n", prog);
+}
+
+static int run_scan(const char *filename, const char *plugin_mode) {
+    const char *plugin_dir = "plugins";
+    char plugins[MAX_PLUGINS][512];
+    size_t plugin_count = discover_plugins(plugin_dir, plugins, MAX_PLUGINS);
+
+    int lines = count_lines(filename);
+    int words = count_words(filename);
+    long bytes = count_bytes(filename);
+
+    if (lines < 0 || words < 0 || bytes < 0) {
+        fprintf(stderr, "Could not open file '%s'.\n", filename);
+        return 1;
+    }
+
+    printf("[scan] file=%s\n", filename);
+    printf("  lines: %d\n", lines);
+    printf("  words: %d\n", words);
+    printf("  bytes: %ld\n", bytes);
+    printf("[plugins] found=%zu\n", plugin_count);
+
+    if (strcmp(plugin_mode, "none") == 0) {
+        return 0;
+    }
+
+    if (strcmp(plugin_mode, "all") == 0) {
+        for (size_t i = 0; i < plugin_count; i++) {
+            printf("\n[plugin] %s\n", plugins[i]);
+            load_and_run_plugin(plugins[i], filename);
+        }
+        return 0;
+    }
+
+    for (size_t i = 0; i < plugin_count; i++) {
+        if (strstr(plugins[i], plugin_mode) != NULL) {
+            printf("\n[plugin] %s\n", plugins[i]);
+            return load_and_run_plugin(plugins[i], filename);
+        }
+    }
+
+    fprintf(stderr, "Plugin mode '%s' not found. Use 'all', 'none', or a plugin name fragment.\n", plugin_mode);
+    return 1;
+}
+
 int main(int argc, char **argv) {
     if (argc < 2) {
-        printf("Usage: %s <file>\n", argv[0]);
-        return 1;
-    }
-    const char *filename = argv[1];
-    int lines = count_lines(filename);
-    if (lines >= 0) {
-        printf("File '%s' has %d lines.\n", filename, lines);
-    } else {
-        printf("Could not open file '%s'.\n", filename);
+        print_usage(argv[0]);
         return 1;
     }
 
-    // Run available plugins if present.
-    if (access("plugins/wordcount.so", R_OK) == 0) {
-        load_and_run_plugin("plugins/wordcount.so", filename);
-    }
-    if (access("plugins/sysinfo.so", R_OK) == 0) {
-        load_and_run_plugin("plugins/sysinfo.so", filename);
-    }
-    if (access("plugins/diskusage.so", R_OK) == 0) {
-        load_and_run_plugin("plugins/diskusage.so", filename);
+    if (strcmp(argv[1], "plugins") == 0) {
+        char plugins[MAX_PLUGINS][512];
+        size_t plugin_count = discover_plugins("plugins", plugins, MAX_PLUGINS);
+        printf("Available plugins (%zu):\n", plugin_count);
+        for (size_t i = 0; i < plugin_count; i++) {
+            printf("- %s\n", plugins[i]);
+        }
+        return 0;
     }
 
-    printf("Done.\n");
+    if (strcmp(argv[1], "scan") == 0) {
+        if (argc < 3) {
+            print_usage(argv[0]);
+            return 1;
+        }
 
-    return 0;
+        const char *plugin_mode = (argc >= 4) ? argv[3] : "all";
+        return run_scan(argv[2], plugin_mode);
+    }
+
+    return run_scan(argv[1], "all");
 }

--- a/src/plugin_manager.c
+++ b/src/plugin_manager.c
@@ -1,6 +1,9 @@
 #include "plugin_manager.h"
+
+#include <dirent.h>
 #include <dlfcn.h>
 #include <stdio.h>
+#include <string.h>
 
 int load_and_run_plugin(const char *path, const char *filename) {
     void *handle = dlopen(path, RTLD_LAZY);
@@ -8,6 +11,7 @@ int load_and_run_plugin(const char *path, const char *filename) {
         fprintf(stderr, "Failed to load plugin %s: %s\n", path, dlerror());
         return 1;
     }
+
     dlerror();
     plugin_run_func run = (plugin_run_func)dlsym(handle, "run");
     const char *err = dlerror();
@@ -16,7 +20,30 @@ int load_and_run_plugin(const char *path, const char *filename) {
         dlclose(handle);
         return 1;
     }
+
     run(filename);
     dlclose(handle);
     return 0;
+}
+
+size_t discover_plugins(const char *plugin_dir, char paths[][512], size_t max_plugins) {
+    DIR *dir = opendir(plugin_dir);
+    if (!dir) {
+        return 0;
+    }
+
+    size_t count = 0;
+    struct dirent *entry;
+    while ((entry = readdir(dir)) != NULL && count < max_plugins) {
+        size_t name_len = strlen(entry->d_name);
+        if (name_len < 4 || strcmp(entry->d_name + name_len - 3, ".so") != 0) {
+            continue;
+        }
+
+        snprintf(paths[count], 512, "%s/%s", plugin_dir, entry->d_name);
+        count++;
+    }
+
+    closedir(dir);
+    return count;
 }

--- a/src/plugin_manager.h
+++ b/src/plugin_manager.h
@@ -1,6 +1,8 @@
 #ifndef PLUGIN_MANAGER_H
 #define PLUGIN_MANAGER_H
 
+#include <stddef.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -8,6 +10,7 @@ extern "C" {
 typedef void (*plugin_run_func)(const char *filename);
 
 int load_and_run_plugin(const char *path, const char *filename);
+size_t discover_plugins(const char *plugin_dir, char paths[][512], size_t max_plugins);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
### Motivation
- Reposition VEN from a prototype editor into a terminal-first, extensible developer toolkit that can run local file and system checks from the CLI.
- Provide richer, reusable core file-analysis APIs so scans can report multiple metrics (lines, words, bytes) for infra checks.
- Replace hardcoded plugin calls with dynamic discovery so teams can drop `.so` plugins into `plugins/` without rebuilding the core.
- Offer clearer CLI workflows for quick scans, explicit scan modes, and plugin discovery to suit terminal-first usage.

### Description
- Updated `README.md` to document the terminal-first focus, CLI usage (`tuxpad <file>`, `tuxpad scan <file> [all|none|fragment]`, `tuxpad plugins`), and the plugin model.
- Extended `src/editor_features.h` and `src/editor_features.c` to add `count_words` and `count_bytes` alongside `count_lines` and exposed these APIs in the header.
- Reworked plugin discovery and management in `src/plugin_manager.h` and `src/plugin_manager.c` by adding `discover_plugins` and keeping `load_and_run_plugin` for dynamic `.so` plugin handling.
- Rewrote `src/main.c` to implement the new CLI flows and a `run_scan` helper that prints scan metrics and executes plugins based on `all`, `none`, or a name fragment.

### Testing
- Built the project with `make` after `make clean`, and the build completed successfully.
- Ran `./tuxpad plugins` to list discovered plugins and it returned the available `.so` entries successfully.
- Ran `./tuxpad scan README.md none` and it printed file metrics without running plugins successfully.
- Ran `./tuxpad README.md` (default quick scan + plugins) and it completed successfully, executing available plugins.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e576c97c5483309f82defde80c4d98)